### PR TITLE
Restrict "stable" stemcell version to 0.7.0

### DIFF
--- a/lib/bosh-cloudfoundry/config/dea_config.rb
+++ b/lib/bosh-cloudfoundry/config/dea_config.rb
@@ -61,7 +61,7 @@ class Bosh::CloudFoundry::Config::DeaConfig
   #   size: 2
   #   stemcell: 
   #     name: bosh-stemcell
-  #     version: 0.6.4
+  #     version: 0.7.0
   #   cloud_properties: 
   #     instance_type: m1.xlarge
   def add_resource_pools_to_manifest(manifest)

--- a/lib/bosh-cloudfoundry/config/postgresql_service_config.rb
+++ b/lib/bosh-cloudfoundry/config/postgresql_service_config.rb
@@ -74,7 +74,7 @@ class Bosh::CloudFoundry::Config::PostgresqlServiceConfig
   #   size: 2
   #   stemcell: 
   #     name: bosh-stemcell
-  #     version: 0.6.4
+  #     version: 0.7.0
   #   cloud_properties: 
   #     instance_type: m1.xlarge
   def add_resource_pools_to_manifest(manifest)

--- a/lib/bosh-cloudfoundry/config/redis_service_config.rb
+++ b/lib/bosh-cloudfoundry/config/redis_service_config.rb
@@ -75,7 +75,7 @@ class Bosh::CloudFoundry::Config::RedisServiceConfig
   #   size: 2
   #   stemcell: 
   #     name: bosh-stemcell
-  #     version: 0.6.4
+  #     version: 0.7.0
   #   cloud_properties: 
   #     instance_type: m1.xlarge
   def add_resource_pools_to_manifest(manifest)

--- a/lib/bosh-cloudfoundry/config_options.rb
+++ b/lib/bosh-cloudfoundry/config_options.rb
@@ -384,7 +384,7 @@ module Bosh::CloudFoundry::ConfigOptions
     @bosh_stemcell_versions ||= begin
       # [{"name"=>"bosh-stemcell", "version"=>"0.6.7", "cid"=>"ami-9730bffe"}]
       stemcells = director.list_stemcells
-      stemcells.select! {|s| s["name"] == stemcell_name}
+      stemcells = stemcells.select {|s| s["name"] == stemcell_name}
       stemcells.map { |rel| rel["version"] }.sort { |v1, v2|
         version_cmp(v1, v2)
       }

--- a/lib/bosh/cli/commands/cf.rb
+++ b/lib/bosh/cli/commands/cf.rb
@@ -436,7 +436,7 @@ module Bosh::Cli::Command
       tags << "stable" if stemcell_type == "stable" unless openstack?
       bosh_stemcells_cmd = "bosh public stemcells --tags #{tags.join(',')}"
       say "Locating bosh stemcell, running '#{bosh_stemcells_cmd}'..."
-      `#{bosh_stemcells_cmd} | grep ' bosh-stemcell-' | grep -V pre | awk '{ print $2 }' | sort -r | head -n 1`.strip
+      `#{bosh_stemcells_cmd} | grep ' bosh-stemcell-' | grep -v pre | awk '{ print $2 }' | sort -r | head -n 1`.strip
     end
 
     def download_stemcell(stemcell_name)

--- a/lib/bosh/cli/commands/cf.rb
+++ b/lib/bosh/cli/commands/cf.rb
@@ -111,7 +111,8 @@ module Bosh::Cli::Command
     usage "cf upload stemcell"
     desc "download/create stemcell & upload to BOSH"
     # option "--stable", "Use latest stemcell; possibly not tagged stable"
-    option "--latest", "Use latest stemcell; possibly not tagged stable [default]"
+    option "--latest", "Use latest stemcell; possibly not tagged stable"
+    option "--version VERSION", "Use base stemcell with specific version [default: 0.7.0]"
     option "--custom", "Create custom stemcell from BOSH git source"
     def upload_stemcell
       stemcell_type = "stable" if options[:stable]
@@ -308,7 +309,7 @@ module Bosh::Cli::Command
           return
         end
       end
-      unless latest_bosh_stemcell_version
+      unless best_bosh_stemcell_version
         if stemcell_name == DEFAULT_STEMCELL_NAME
           say "Attempting to upload stemcell #{stemcell_name}..."
           upload_stemcell
@@ -340,6 +341,13 @@ module Bosh::Cli::Command
       else
         false
       end
+    end
+
+    # An attempt to choose the best base stemcell for the current
+    # BOSH. Currently it hardcodes a guess on the assumption that
+    # the BOSH is from 0.8.1; rather than current edge (1.5.0.preX)
+    def best_bosh_stemcell_version
+      "0.7.0"
     end
 
     # Largest version number BOSH stemcell ("bosh-stemcell")

--- a/lib/bosh/cli/commands/cf.rb
+++ b/lib/bosh/cli/commands/cf.rb
@@ -319,12 +319,12 @@ module Bosh::Cli::Command
         end
       end
       unless stemcell_version && stemcell_version.size
-        system_config.stemcell_version = latest_bosh_stemcell_version
+        system_config.stemcell_version = best_bosh_stemcell_version
         system_config.save
       end
       unless bosh_stemcell_versions.include?(stemcell_version)
         say "Requested stemcell version #{stemcell_version} is not available.".yellow
-        system_config.stemcell_version = latest_bosh_stemcell_version
+        system_config.stemcell_version = best_bosh_stemcell_version
         system_config.save
       end
       say "Using stemcell #{stemcell_name} #{stemcell_version}".green

--- a/lib/bosh/cli/commands/cf.rb
+++ b/lib/bosh/cli/commands/cf.rb
@@ -309,7 +309,7 @@ module Bosh::Cli::Command
           return
         end
       end
-      unless best_bosh_stemcell_version
+      unless latest_bosh_stemcell_version
         if stemcell_name == DEFAULT_STEMCELL_NAME
           say "Attempting to upload stemcell #{stemcell_name}..."
           upload_stemcell
@@ -350,7 +350,7 @@ module Bosh::Cli::Command
       "0.7.0"
     end
 
-    # Largest version number BOSH stemcell ("bosh-stemcell")
+    # Largest version number BOSH stemcell ("bosh-stemcell") uploaded to BOSH
     # @return [String] version number, e.g. "0.6.7"
     def latest_bosh_stemcell_version
       @latest_bosh_stemcell_version ||= begin

--- a/spec/assets/deployments/aws-core-1-m1.small-free-redis.yml
+++ b/spec/assets/deployments/aws-core-1-m1.small-free-redis.yml
@@ -33,7 +33,7 @@ resource_pools:
   size: 1
   stemcell: 
     name: bosh-stemcell
-    version: 0.6.4
+    version: 0.7.0
   cloud_properties: 
     instance_type: m1.small
   persistent_disk: 16192
@@ -42,7 +42,7 @@ resource_pools:
   size: 1
   stemcell: 
     name: bosh-stemcell
-    version: 0.6.4
+    version: 0.7.0
   cloud_properties: 
     instance_type: m1.small
   persistent_disk: 16192

--- a/spec/assets/deployments/aws-core-1-m1.xlarge-free-postgresql-2-m1.small-free-postgresql.yml
+++ b/spec/assets/deployments/aws-core-1-m1.xlarge-free-postgresql-2-m1.small-free-postgresql.yml
@@ -33,7 +33,7 @@ resource_pools:
   size: 1
   stemcell: 
     name: bosh-stemcell
-    version: 0.6.4
+    version: 0.7.0
   cloud_properties: 
     instance_type: m1.small
   persistent_disk: 16192
@@ -42,7 +42,7 @@ resource_pools:
   size: 1
   stemcell: 
     name: bosh-stemcell
-    version: 0.6.4
+    version: 0.7.0
   cloud_properties: 
     instance_type: m1.xlarge
   persistent_disk: 16192
@@ -51,7 +51,7 @@ resource_pools:
   size: 2
   stemcell: 
     name: bosh-stemcell
-    version: 0.6.4
+    version: 0.7.0
   cloud_properties: 
     instance_type: m1.small
   persistent_disk: 16192

--- a/spec/assets/deployments/aws-core-2-m1.xlarge-dea.yml
+++ b/spec/assets/deployments/aws-core-2-m1.xlarge-dea.yml
@@ -33,7 +33,7 @@ resource_pools:
   size: 1
   stemcell: 
     name: bosh-stemcell
-    version: 0.6.4
+    version: 0.7.0
   cloud_properties: 
     instance_type: m1.small
   persistent_disk: 16192
@@ -42,7 +42,7 @@ resource_pools:
   size: 2
   stemcell: 
     name: bosh-stemcell
-    version: 0.6.4
+    version: 0.7.0
   cloud_properties: 
     instance_type: m1.xlarge
 jobs: 

--- a/spec/assets/deployments/aws-core-only.yml
+++ b/spec/assets/deployments/aws-core-only.yml
@@ -33,7 +33,7 @@ resource_pools:
   size: 1
   stemcell: 
     name: bosh-stemcell
-    version: 0.6.4
+    version: 0.7.0
   cloud_properties: 
     instance_type: m1.small
   persistent_disk: 16192

--- a/spec/assets/deployments/aws-core-with-nfs.yml
+++ b/spec/assets/deployments/aws-core-with-nfs.yml
@@ -33,7 +33,7 @@ resource_pools:
   size: 1
   stemcell: 
     name: bosh-stemcell
-    version: 0.6.4
+    version: 0.7.0
   cloud_properties: 
     instance_type: m1.small
   persistent_disk: 16192

--- a/spec/unit/cf_command_spec.rb
+++ b/spec/unit/cf_command_spec.rb
@@ -154,7 +154,7 @@ describe Bosh::Cli::Command::Base do
         ])
       end
 
-      cmd.should_receive(:bosh_stemcell_versions).exactly(4).times.and_return(['0.6.4'])
+      cmd.should_receive(:bosh_stemcell_versions).exactly(4).times.and_return(['0.7.0'])
       cmd.should_receive(:render_system)
 
       provider = Bosh::CloudFoundry::Providers::AWS.new

--- a/spec/unit/cf_command_spec.rb
+++ b/spec/unit/cf_command_spec.rb
@@ -43,11 +43,11 @@ describe Bosh::Cli::Command::Base do
       @cmd.stub!(:bosh_target_uuid).and_return("DIRECTOR_UUID")
       @cmd.stub!(:bosh_cpi).and_return("aws")
       @cmd.should_receive(:`).
-        with("bosh public stemcells --tags aws | grep ' bosh-stemcell-' | awk '{ print $2 }' | sort -r | head -n 1").
+        with("bosh public stemcells --tags aws | grep ' bosh-stemcell-' | grep -V pre | awk '{ print $2 }' | sort -r | head -n 1").
         and_return("bosh-stemcell-aws-0.6.7.tgz")
       # FIXME default to stable stemcells when 0.8.1 is marked stable
       # @cmd.should_receive(:`).
-      #   with("bosh public stemcells --tags aws,stable | grep ' bosh-stemcell-' | awk '{ print $2 }' | sort -r | head -n 1").
+      #   with("bosh public stemcells --tags aws,stable | grep ' bosh-stemcell-' | grep -V pre | awk '{ print $2 }' | sort -r | head -n 1").
       #   and_return("bosh-stemcell-aws-0.6.7.tgz")
       @cmd.should_receive(:sh).
         with("bosh -n --color download public stemcell bosh-stemcell-aws-0.6.7.tgz")

--- a/spec/unit/cf_command_spec.rb
+++ b/spec/unit/cf_command_spec.rb
@@ -43,11 +43,11 @@ describe Bosh::Cli::Command::Base do
       @cmd.stub!(:bosh_target_uuid).and_return("DIRECTOR_UUID")
       @cmd.stub!(:bosh_cpi).and_return("aws")
       @cmd.should_receive(:`).
-        with("bosh public stemcells --tags aws | grep ' bosh-stemcell-' | grep -V pre | awk '{ print $2 }' | sort -r | head -n 1").
+        with("bosh public stemcells --tags aws | grep ' bosh-stemcell-' | grep -v pre | awk '{ print $2 }' | sort -r | head -n 1").
         and_return("bosh-stemcell-aws-0.6.7.tgz")
       # FIXME default to stable stemcells when 0.8.1 is marked stable
       # @cmd.should_receive(:`).
-      #   with("bosh public stemcells --tags aws,stable | grep ' bosh-stemcell-' | grep -V pre | awk '{ print $2 }' | sort -r | head -n 1").
+      #   with("bosh public stemcells --tags aws,stable | grep ' bosh-stemcell-' | grep -v pre | awk '{ print $2 }' | sort -r | head -n 1").
       #   and_return("bosh-stemcell-aws-0.6.7.tgz")
       @cmd.should_receive(:sh).
         with("bosh -n --color download public stemcell bosh-stemcell-aws-0.6.7.tgz")

--- a/spec/unit/system_deployment_manifest_renderer_spec.rb
+++ b/spec/unit/system_deployment_manifest_renderer_spec.rb
@@ -25,7 +25,7 @@ describe Bosh::CloudFoundry::SystemDeploymentManifestRenderer do
     @system_config.release_name = 'appcloud'
     @system_config.release_version = 'latest'
     @system_config.stemcell_name = 'bosh-stemcell'
-    @system_config.stemcell_version = '0.6.4'
+    @system_config.stemcell_version = '0.7.0'
     @system_config.core_server_flavor = 'm1.small'
     @system_config.core_ip = '1.2.3.4'
     @system_config.root_dns = 'mycompany.com'


### PR DESCRIPTION
Similar to https://github.com/StarkAndWayne/bosh-bootstrap/pull/116

If using 0.8.1 for microbosh; then use 0.7.0 base stemcells.
