### PR TITLE
Switch back to "staging" branch, which is actually the "v1" branch

### DIFF
--- a/lib/bosh-cloudfoundry/bosh_release_manager.rb
+++ b/lib/bosh-cloudfoundry/bosh_release_manager.rb
@@ -97,7 +97,7 @@ module Bosh::CloudFoundry::BoshReleaseManager
 
   # clones or updates cf-release for a specific branch
   # For all defaults, clones into:
-  # * /var/vcap/store/releases/cf-release/master (cf_release_branch_dir)
+  # * /var/vcap/store/releases/cf-release/staging (cf_release_branch_dir)
   #
   # Uses:
   # * releases_dir (e.g. '/var/vcap/store/releases')

--- a/lib/bosh/cli/commands/cf.rb
+++ b/lib/bosh/cli/commands/cf.rb
@@ -136,7 +136,7 @@ module Bosh::Cli::Command
       switch_to_development_release unless system_config.release_type
         
       if dev_release_type?
-        new_branch ||= "master"
+        new_branch ||= "staging"
         set_cf_release_branch(new_branch)
         clone_or_update_cf_release
         prepare_cf_release_for_dev_release
@@ -550,7 +550,7 @@ module Bosh::Cli::Command
       common_password
       security_group
 
-      set_cf_release_branch("master")
+      set_cf_release_branch("staging")
     end
 
     # Renders the +SystemConfig+ model (+system_config+) into the system's

--- a/spec/unit/bosh_release_manager_spec.rb
+++ b/spec/unit/bosh_release_manager_spec.rb
@@ -35,8 +35,8 @@ describe Bosh::CloudFoundry::BoshReleaseManager do
   end
 
   it "prepare_cf_release_for_dev_release" do
-    self.cf_release_branch     = "master"
-    self.cf_release_branch_dir = File.join(cf_release_dir, "master")
+    self.cf_release_branch     = "staging"
+    self.cf_release_branch_dir = File.join(cf_release_dir, "staging")
     mkdir_p(cf_release_branch_dir)
     should_receive(:sh).with("sed -i 's#git@github.com:#https://github.com/#g' .gitmodules")
     should_receive(:sh).with("sed -i 's#git://github.com#https://github.com#g' .gitmodules")
@@ -46,17 +46,17 @@ describe Bosh::CloudFoundry::BoshReleaseManager do
 
   describe "switch release types" do
     it "from final to dev" do
-      self.cf_release_branch     = "master"
+      self.cf_release_branch     = "staging"
       @system_config.release_name = "appcloud"
       @system_config.release_version = "latest"
       @system_config.save
       switch_to_development_release
-      @system_config.release_name.should == "appcloud-master"
+      @system_config.release_name.should == "appcloud-staging"
       @system_config.release_version.should == "latest"
     end
 
     it "from dev to final" do
-      @system_config.release_name = "appcloud-master"
+      @system_config.release_name = "appcloud-staging"
       @system_config.release_version = "latest"
       @system_config.save
       switch_to_final_release

--- a/spec/unit/cf_command_spec.rb
+++ b/spec/unit/cf_command_spec.rb
@@ -86,7 +86,7 @@ describe Bosh::Cli::Command::Base do
       cf_release_dir = File.join(@releases_dir, "cf-release")
       @cmd.system_config.cf_release_dir = cf_release_dir
       @cmd.system_config.cf_release_branch = "master"
-      @cmd.system_config.cf_release_branch_dir = File.join(cf_release_dir, "master")
+      @cmd.system_config.cf_release_branch_dir = File.join(cf_release_dir, "staging")
       FileUtils.mkdir_p(@cmd.system_config.cf_release_branch_dir)
 
       @cmd.should_receive(:sh).with("git pull origin master")
@@ -102,11 +102,11 @@ describe Bosh::Cli::Command::Base do
 
       cf_release_dir = File.join(@releases_dir, "cf-release")
       @cmd.system_config.cf_release_dir = cf_release_dir
-      @cmd.system_config.cf_release_branch = "master"
-      @cmd.system_config.cf_release_branch_dir = File.join(cf_release_dir, "master")
+      @cmd.system_config.cf_release_branch = "staging"
+      @cmd.system_config.cf_release_branch_dir = File.join(cf_release_dir, "staging")
       FileUtils.mkdir_p(@cmd.system_config.cf_release_branch_dir)
 
-      @cmd.should_receive(:sh).with("git pull origin master")
+      @cmd.should_receive(:sh).with("git pull origin staging")
       script = <<-BASH.gsub(/^      /, '')
       grep -rI "github.com" * .gitmodules | awk 'BEGIN {FS=":"} { print($1) }' | uniq while read file
       do
@@ -118,11 +118,11 @@ describe Bosh::Cli::Command::Base do
       @cmd.should_receive(:sh).with("sed -i 's#git@github.com:#https://github.com/#g' .gitmodules")
       @cmd.should_receive(:sh).with("sed -i 's#git://github.com#https://github.com#g' .gitmodules")
       @cmd.should_receive(:sh).with("git submodule update --init --recursive")
-      @cmd.should_receive(:write_dev_config_file).with("appcloud-master")
+      @cmd.should_receive(:write_dev_config_file).with("appcloud-staging")
       @cmd.should_receive(:sh).with("bosh -n --color create release --with-tarball --force")
       @cmd.should_receive(:sh).with("bosh -n --color upload release")
 
-      @cmd.add_option(:branch, "master")
+      @cmd.add_option(:branch, "staging")
       @cmd.upload_release
     end
 
@@ -151,14 +151,14 @@ describe Bosh::Cli::Command::Base do
         # TODO revert to these when appcloud-130 is released; and we go to final release
         # cmd.should_receive(:clone_or_update_cf_release)
         # cmd.should_receive(:upload_final_release)
-        cmd.should_receive(:set_cf_release_branch).with("master").exactly(2).times
+        cmd.should_receive(:set_cf_release_branch).with("staging").exactly(2).times
         cmd.should_receive(:clone_or_update_cf_release)
         cmd.should_receive(:prepare_cf_release_for_dev_release)
         cmd.should_receive(:create_and_upload_dev_release)
       else
         cmd.should_receive(:bosh_releases).exactly(1).times.and_return([
           {"name"=>"appcloud", "versions"=>["124", "126", "129"], "in_use"=>[]},
-          {"name"=>"appcloud-master", "versions"=>["124.1-dev", "126.1-dev"], "in_use"=>[]},
+          {"name"=>"appcloud-staging", "versions"=>["124.1-dev", "126.1-dev"], "in_use"=>[]},
         ])
       end
 


### PR DESCRIPTION
In a conversation with Tim Labeeuw & @mreider I was educated that the "staging"
branch of cf-release is currently actually the "stable cloudfoundry v1 components" branch.
If we switch to using staging branch then we should have fewer breaking changes.
