### PR TITLE
token_creation_email_filter: "<%= cc_props.uaa.token_creation_email_filter %>" resolves to "[""]"

### DIFF
--- a/lib/bosh-cloudfoundry/system_deployment_manifest_renderer.rb
+++ b/lib/bosh-cloudfoundry/system_deployment_manifest_renderer.rb
@@ -231,7 +231,7 @@ class Bosh::CloudFoundry::SystemDeploymentManifestRenderer
          "uaa"=>
           {"enabled"=>true,
            "resource_id"=>"cloud_controller",
-           "token_creation_email_filter"=>[""]},
+           "token_creation_email_filter"=>""},
          "service_extension"=>{"service_lifecycle"=>{"max_upload_size"=>5}},
          "use_nginx"=>false},
        "postgresql_server"=>{"max_connections"=>30, "listen_address"=>"0.0.0.0"},


### PR DESCRIPTION
Using cf-release master/HEAD we're missing field `cc_props.uaa.token_creation_email_filter`

In the generated manifest.yml, we are creating:

``` yaml
    uaa:
      enabled: true
      resource_id: cloud_controller
      token_creation_email_filter:
      - ''
```

Caused by https://github.com/cloudfoundry/cf-release/commit/0ee42dd9
