### PR TITLE
Hardcode release name/version in templates

### DIFF
--- a/lib/bosh/cloudfoundry/deployment_file.rb
+++ b/lib/bosh/cloudfoundry/deployment_file.rb
@@ -38,8 +38,8 @@ module Bosh::Cloudfoundry
     # name: NAME
     # director_uuid: 4ae3a0f0-70a5-4c0d-95f2-7fafaefe8b9e
     # releases:
-    #  - name: cf-release
-    #    version: 132
+    # - name: cf-release
+    #   version: 132
     # networks: {}
     # properties:
     #   cf:
@@ -111,8 +111,6 @@ module Bosh::Cloudfoundry
       end
       release_version = release["version"]
       release_version_cpi = ReleaseVersionCpi.new(release_version, bosh_cpi)
-      deployment_size = deployment_file["properties"]["deployment_size"]
-      release_version_cpi_size = ReleaseVersionCpiSize.new(release_version_cpi, deployment_size)
 
       attributes = deployment_file["properties"][properties_key]
       # convert string keys to symbol keys
@@ -120,6 +118,9 @@ module Bosh::Cloudfoundry
         k, v = key_value; mem[k.to_sym] = v; mem
       end
       deployment_attributes = DeploymentAttributes.new(director_client, bosh_status, release_version_cpi, attributes)
+
+      deployment_size = deployment_attributes.deployment_size
+      release_version_cpi_size = ReleaseVersionCpiSize.new(release_version_cpi, deployment_size)
 
       self.new(release_version_cpi_size, deployment_attributes, bosh_status)
     end

--- a/lib/bosh/cloudfoundry/deployment_file.rb
+++ b/lib/bosh/cloudfoundry/deployment_file.rb
@@ -37,9 +37,6 @@ module Bosh::Cloudfoundry
     # ---
     # name: NAME
     # director_uuid: 4ae3a0f0-70a5-4c0d-95f2-7fafaefe8b9e
-    # releases:
-    # - name: cf-release
-    #   version: 132
     # networks: {}
     # properties:
     #   cf:
@@ -57,10 +54,6 @@ module Bosh::Cloudfoundry
           file << {
             "name" => deployment_attributes.name,
             "director_uuid" => bosh_uuid,
-            "releases" => [{
-              "name" => release_name,
-              "version" => release_version_number
-            }],
             "networks" => {},
             "properties" => {
               self.class.properties_key => deployment_attributes.attributes_with_string_keys

--- a/lib/bosh/cloudfoundry/deployment_file.rb
+++ b/lib/bosh/cloudfoundry/deployment_file.rb
@@ -57,10 +57,10 @@ module Bosh::Cloudfoundry
           file << {
             "name" => deployment_attributes.name,
             "director_uuid" => bosh_uuid,
-            "releases" => {
+            "releases" => [{
               "name" => release_name,
               "version" => release_version_number
-            },
+            }],
             "networks" => {},
             "properties" => {
               self.class.properties_key => deployment_attributes.attributes_with_string_keys

--- a/spec/deployment_file_spec.rb
+++ b/spec/deployment_file_spec.rb
@@ -76,18 +76,18 @@ describe Bosh::Cloudfoundry::DeploymentFile do
         subject.deploy(non_interactive: true)
       end
     end
-  # 
-  # it "generates a large deployment" do
-  #   in_home_dir do
-  #     command.add_option(:deployment_size, "large")
-  # 
-  #     command.create_cf
-  #     files_match(spec_asset("v132/aws/large.yml"), command.deployment_file)
-  # 
-  #     manifest = YAML.load_file(command.deployment_file)
-  #     Bosh::Cli::DeploymentManifest.new(manifest).normalize
-  #   end
-  # end
+
+    # it "large size" do
+    #   in_home_dir do
+    #     command.add_option(:deployment_size, "large")
+    # 
+    #     command.create_cf
+    #     files_match(spec_asset("v133/aws/large.yml"), command.deployment_file)
+    # 
+    #     manifest = YAML.load_file(command.deployment_file)
+    #     Bosh::Cli::DeploymentManifest.new(manifest).normalize
+    #   end
+    # end
   # 
   # it "specifies core size" do
   #   in_home_dir do

--- a/templates/v132/aws/large/deployment_file.yml.erb
+++ b/templates/v132/aws/large/deployment_file.yml.erb
@@ -39,7 +39,7 @@ director_uuid: <%= find("director_uuid") %>
 
 releases:
  - name: cf-release
-   version: <%= find("releases.version") %>
+   version: 132
 
 networks:
 - name: floating

--- a/templates/v132/aws/medium/deployment_file.yml.erb
+++ b/templates/v132/aws/medium/deployment_file.yml.erb
@@ -39,7 +39,7 @@ director_uuid: <%= find("director_uuid") %>
 
 releases:
  - name: cf-release
-   version: <%= find("releases.version") %>
+   version: 132
 
 networks:
 - name: floating

--- a/templates/v132/openstack/large/deployment_file.yml.erb
+++ b/templates/v132/openstack/large/deployment_file.yml.erb
@@ -39,7 +39,7 @@ director_uuid: <%= find("director_uuid") %>
 
 releases:
  - name: cf-release
-   version: <%= find("releases.version") %>
+   version: 132
 
 networks:
 - name: floating

--- a/templates/v132/openstack/medium/deployment_file.yml.erb
+++ b/templates/v132/openstack/medium/deployment_file.yml.erb
@@ -39,7 +39,7 @@ director_uuid: <%= find("director_uuid") %>
 
 releases:
  - name: cf-release
-   version: <%= find("releases.version") %>
+   version: 132
 
 networks:
 - name: floating

--- a/templates/v133/aws/large/deployment_file.yml.erb
+++ b/templates/v133/aws/large/deployment_file.yml.erb
@@ -39,7 +39,7 @@ director_uuid: <%= find("director_uuid") %>
 
 releases:
  - name: cf-release
-   version: <%= find("releases.version") %>
+   version: 133
 
 networks:
 - name: floating

--- a/templates/v133/aws/medium/deployment_file.yml.erb
+++ b/templates/v133/aws/medium/deployment_file.yml.erb
@@ -39,7 +39,7 @@ director_uuid: <%= find("director_uuid") %>
 
 releases:
  - name: cf-release
-   version: <%= find("releases.version") %>
+   version: 133
 
 networks:
 - name: floating

--- a/templates/v133/openstack/large/deployment_file.yml.erb
+++ b/templates/v133/openstack/large/deployment_file.yml.erb
@@ -39,7 +39,7 @@ director_uuid: <%= find("director_uuid") %>
 
 releases:
  - name: cf-release
-   version: <%= find("releases.version") %>
+   version: 133
 
 networks:
 - name: floating

--- a/templates/v133/openstack/medium/deployment_file.yml.erb
+++ b/templates/v133/openstack/medium/deployment_file.yml.erb
@@ -39,7 +39,7 @@ director_uuid: <%= find("director_uuid") %>
 
 releases:
  - name: cf-release
-   version: <%= find("releases.version") %>
+   version: 133
 
 networks:
 - name: floating


### PR DESCRIPTION
This is a temporary measure until #190 is implemented (not required until v134 or later appears that itself doesn't require a new template)
