### PR TITLE
No login for large deployments

### DIFF
--- a/spec/assets/v133/aws/large.yml
+++ b/spec/assets/v133/aws/large.yml
@@ -14,7 +14,7 @@ networks:
   type: dynamic
   cloud_properties:
     security_groups:
-    - cf
+    - default
 
 compilation:
   workers: 6
@@ -33,7 +33,7 @@ update:
 resource_pools:
   - name: small
     network: default
-    size: 9
+    size: 8
     stemcell:
       name: bosh-stemcell
       version: latest
@@ -105,16 +105,6 @@ jobs:
       - name: default
         default: [dns, gateway]           
 
-  - name: login
-    release: cf-release
-    template: 
-      - login
-    instances: 1
-    resource_pool: small
-    networks:
-      - name: default
-        default: [dns, gateway]
-
   - name: cloud_controller
     release: cf-release
     template: 
@@ -164,8 +154,8 @@ properties:
     name: demo
     dns: mycloud.com
     ip_addresses: ["1.2.3.4"]
-    deployment_size: medium
-    security_group: cf
+    deployment_size: large
+    security_group: default
     persistent_disk: 4096
     common_password: qwertyasdfgh
 
@@ -202,24 +192,14 @@ properties:
 
   dea_next: *dea
 
-  service_lifecycle:
-    serialization_data_server:
-    - 169.254.1.1 
-
   syslog_aggregator:
     address: 0.syslog-aggregator.default.demo.microbosh
     port: 54321
 
-  serialization_data_server:
-    port: 8080
-    logging_level: debug
-    upload_token: qwertyasdfgh
-    upload_timeout: 10
-
   nfs_server:
     address: 0.nfs-server.default.demo.microbosh
-    # network: "*.demo.microbosh"
-    # idmapd_domain: mycloud.com
+    network: "*.demo.microbosh"
+    idmapd_domain: mycloud.com
 
   debian_nfs_server:
     no_root_squash: true
@@ -298,11 +278,7 @@ properties:
   ccng: *cc
 
   login:
-    protocol: http
-    links:
-      home: http://console.mycloud.com
-      passwd: http://console.mycloud.com/password_resets/new
-      signup: http://console.mycloud.com/register
+    enabled: false
 
   uaa:
     url: http://uaa.mycloud.com
@@ -344,34 +320,7 @@ properties:
     client:
       autoapprove:
         - cf
-        - my
-        - micro
-        - support-signon
-        - login
     clients:
-      login:
-        override: true
-        scope: openid
-        authorities: oauth.login
-        secret: qwertyasdfgh
-        authorized-grant-types: authorization_code,client_credentials,refresh_token
-        redirect-uri: http://login.mycloud.com
-      support-services:
-        scope: scim.write,scim.read,openid,cloud_controller.read,cloud_controller.write
-        secret: qwertyasdfgh
-        authorized-grant-types: authorization_code,client_credentials
-        redirect-uri: http://support-signon.mycloud.com
-        authorities: portal.users.read
-        access-token-validity: 1209600
-        refresh-token-validity: 1209600
-      oauth2service:
-        secret: qwertyasdfgh
-        scope: openid,cloud_controller.read,cloud_controller.write
-        authorities: uaa.resource,oauth.service,clients.read,clients.write,clients.secret
-        authorized-grant-types: client_credentials,implicit
-        redirect-uri: http://rewritten-later.cloudfoundry.com/whatever
-        override: true
-        autoapprove: true
       cf:
         override: true
         authorized-grant-types: password,implicit,refresh_token
@@ -379,14 +328,6 @@ properties:
         scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write
         access-token-validity: 7200
         refresh-token-validity: 1209600
-      servicesmgmt:
-        override: true
-        secret: qwertyasdfgh
-        scope: openid,cloud_controller.read,cloud_controller.write
-        authorities: uaa.resource,oauth.service,clients.read,clients.write,clients.secret
-        authorized-grant-types: authorization_code,client_credentials,password,implicit
-        redirect-uri: http://servicesmgmt.mycloud.com/auth/cloudfoundry/callback
-        autoapprove: true
     scim:
       users:
       - admin|qwertyasdfgh|scim.write,scim.read,openid,cloud_controller.admin

--- a/spec/assets/v133/aws/medium.yml
+++ b/spec/assets/v133/aws/medium.yml
@@ -275,18 +275,7 @@ properties:
     client:
       autoapprove:
         - cf
-        - my
-        - micro
-        - support-signon
     clients:
-      oauth2service:
-        secret: qwertyasdfgh
-        scope: openid,cloud_controller.read,cloud_controller.write
-        authorities: uaa.resource,oauth.service,clients.read,clients.write,clients.secret
-        authorized-grant-types: client_credentials,implicit
-        redirect-uri: http://rewritten-later.cloudfoundry.com/whatever
-        override: true
-        autoapprove: true
       cf:
         override: true
         authorized-grant-types: password,implicit,refresh_token
@@ -294,14 +283,6 @@ properties:
         scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write
         access-token-validity: 7200
         refresh-token-validity: 1209600
-      servicesmgmt:
-        override: true
-        secret: qwertyasdfgh
-        scope: openid,cloud_controller.read,cloud_controller.write
-        authorities: uaa.resource,oauth.service,clients.read,clients.write,clients.secret
-        authorized-grant-types: authorization_code,client_credentials,password,implicit
-        redirect-uri: http://servicesmgmt.mycloud.com/auth/cloudfoundry/callback
-        autoapprove: true
     scim:
       users:
       - admin|qwertyasdfgh|scim.write,scim.read,openid,cloud_controller.admin

--- a/spec/deployment_file_spec.rb
+++ b/spec/deployment_file_spec.rb
@@ -39,43 +39,44 @@ describe Bosh::Cloudfoundry::DeploymentFile do
   # v132 & v133
   # medium & large
 
-  context "generates deployment (aws)" do
-    let(:bosh_cpi) { "aws" }
-    let(:bosh_status) { {"cpi" => bosh_cpi, "uuid" => "UUID"} }
-    let(:attributes) { {
-      name: "demo",
-      dns: "mycloud.com",
-      ip_addresses: ['1.2.3.4'],
-      common_password: "qwertyasdfgh",
-      deployment_size: "medium"
-    } }
-    let(:release_version_cpi) { Bosh::Cloudfoundry::ReleaseVersionCpi.for_cpi(133, bosh_cpi) }
-    let(:release_version_cpi_medium) { Bosh::Cloudfoundry::ReleaseVersionCpiSize.new(release_version_cpi, "medium") }
-    let(:deployment_attributes) do
-      Bosh::Cloudfoundry::DeploymentAttributes.new(mock("director"), bosh_status, release_version_cpi_medium, attributes)
-    end
+  %w[medium large].each do |deployment_size|
+    context "generates deployment (aws)" do
+      let(:bosh_cpi) { "aws" }
+      let(:bosh_status) { {"cpi" => bosh_cpi, "uuid" => "UUID"} }
+      let(:attributes) { {
+        name: "demo",
+        dns: "mycloud.com",
+        ip_addresses: ['1.2.3.4'],
+        common_password: "qwertyasdfgh",
+        deployment_size: deployment_size
+      } }
+      let(:release_version_cpi) { Bosh::Cloudfoundry::ReleaseVersionCpi.for_cpi(133, bosh_cpi) }
+      let(:release_version_cpi_size) { Bosh::Cloudfoundry::ReleaseVersionCpiSize.new(release_version_cpi, deployment_size) }
+      let(:deployment_attributes) do
+        Bosh::Cloudfoundry::DeploymentAttributes.new(mock("director"), bosh_status, release_version_cpi_size, attributes)
+      end
 
-    subject { Bosh::Cloudfoundry::DeploymentFile.new(release_version_cpi_medium, deployment_attributes, bosh_status) }
+      subject { Bosh::Cloudfoundry::DeploymentFile.new(release_version_cpi_size, deployment_attributes, bosh_status) }
 
-    before do
-      subject.biff.stub(:deployment).and_return(home_file("deployments/cf/demo.yml"))
-      deployment_cmd = mock("deployment_cmd")
-      deployment_cmd.stub(:set_current).with(home_file("deployments/cf/demo.yml"))
-      deployment_cmd.stub(:perform)
-      subject.stub(:deployment_cmd).and_return(deployment_cmd)
-    end
+      before do
+        subject.biff.stub(:deployment).and_return(home_file("deployments/cf/demo.yml"))
+        deployment_cmd = mock("deployment_cmd")
+        deployment_cmd.stub(:set_current).with(home_file("deployments/cf/demo.yml"))
+        deployment_cmd.stub(:perform)
+        subject.stub(:deployment_cmd).and_return(deployment_cmd)
+      end
 
-    it "medium size" do
-      in_home_dir do
-        subject.prepare_environment
+      it "#{deployment_size} size" do
+        in_home_dir do
+          subject.prepare_environment
 
-        subject.create_deployment_file
-        files_match(spec_asset("v133/aws/medium.yml"), subject.deployment_file)
+          subject.create_deployment_file
+          files_match(spec_asset("v133/aws/#{deployment_size}.yml"), subject.deployment_file)
 
-        subject.deploy(non_interactive: true)
+          subject.deploy(non_interactive: true)
+        end
       end
     end
-
     # it "large size" do
     #   in_home_dir do
     #     command.add_option(:deployment_size, "large")

--- a/templates/v132/aws/medium/deployment_file.yml.erb
+++ b/templates/v132/aws/medium/deployment_file.yml.erb
@@ -338,34 +338,7 @@ properties:
     client:
       autoapprove:
         - cf
-        - my
-        - micro
-        - support-signon
-        - login
     clients:
-      login:
-        override: true
-        scope: openid
-        authorities: oauth.login
-        secret: <%= common_password %>
-        authorized-grant-types: authorization_code,client_credentials,refresh_token
-        redirect-uri: <%= protocol %>://login.<%= dns %>
-      support-services:
-        scope: scim.write,scim.read,openid,cloud_controller.read,cloud_controller.write
-        secret: <%= common_password %>
-        authorized-grant-types: authorization_code,client_credentials
-        redirect-uri: <%= protocol %>://support-signon.<%= dns %>
-        authorities: portal.users.read
-        access-token-validity: 1209600
-        refresh-token-validity: 1209600
-      oauth2service:
-        secret: <%= common_password %>
-        scope: openid,cloud_controller.read,cloud_controller.write
-        authorities: uaa.resource,oauth.service,clients.read,clients.write,clients.secret
-        authorized-grant-types: client_credentials,implicit
-        redirect-uri: <%= protocol %>://rewritten-later.cloudfoundry.com/whatever
-        override: true
-        autoapprove: true
       cf:
         override: true
         authorized-grant-types: password,implicit,refresh_token
@@ -373,14 +346,6 @@ properties:
         scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write
         access-token-validity: 7200
         refresh-token-validity: 1209600
-      servicesmgmt:
-        override: true
-        secret: <%= common_password %>
-        scope: openid,cloud_controller.read,cloud_controller.write
-        authorities: uaa.resource,oauth.service,clients.read,clients.write,clients.secret
-        authorized-grant-types: authorization_code,client_credentials,password,implicit
-        redirect-uri: <%= protocol %>://servicesmgmt.mycloud.com/auth/cloudfoundry/callback
-        autoapprove: true
     scim:
       users:
       - admin|<%= common_password %>|scim.write,scim.read,openid,cloud_controller.admin

--- a/templates/v133/aws/large/deployment_file.yml.erb
+++ b/templates/v133/aws/large/deployment_file.yml.erb
@@ -68,7 +68,7 @@ update:
 resource_pools:
   - name: small
     network: default
-    size: 9
+    size: 8
     stemcell:
       name: bosh-stemcell
       version: latest
@@ -139,16 +139,6 @@ jobs:
     networks:
       - name: default
         default: [dns, gateway]           
-
-  - name: login
-    release: cf-release
-    template: 
-      - login
-    instances: 1
-    resource_pool: small
-    networks:
-      - name: default
-        default: [dns, gateway]
 
   - name: cloud_controller
     release: cf-release
@@ -239,19 +229,9 @@ properties:
 
   dea_next: *dea
 
-  service_lifecycle:
-    serialization_data_server:
-    - 169.254.1.1 
-
   syslog_aggregator:
     address: 0.syslog-aggregator.default.<%= name %>.microbosh
     port: 54321
-
-  serialization_data_server:
-    port: 8080
-    logging_level: debug
-    upload_token: <%= common_password %>
-    upload_timeout: 10
 
   nfs_server:
     address: 0.nfs-server.default.<%= name %>.microbosh
@@ -335,11 +315,7 @@ properties:
   ccng: *cc
 
   login:
-    protocol: <%= protocol %>
-    links:
-      home: <%= protocol %>://console.<%= dns %>
-      passwd: <%= protocol %>://console.<%= dns %>/password_resets/new
-      signup: <%= protocol %>://console.<%= dns %>/register
+    enabled: false
 
   uaa:
     url: <%= protocol %>://uaa.<%= dns %>
@@ -376,40 +352,12 @@ properties:
     admin:
       client_secret: <%= common_password %>
     batch:
-      username: batch
+      username: batchuser
       password: <%= common_password %>
     client:
       autoapprove:
         - cf
-        - my
-        - portal
-        - micro
-        - support-signon
-        - login
     clients:
-      login:
-        override: true
-        scope: openid
-        authorities: oauth.login
-        secret: <%= common_password %>
-        authorized-grant-types: authorization_code,client_credentials,refresh_token
-        redirect-uri: <%= protocol %>://login.<%= dns %>
-      support-services:
-        scope: scim.write,scim.read,openid,cloud_controller.read,cloud_controller.write
-        secret: <%= common_password %>
-        authorized-grant-types: authorization_code,client_credentials
-        redirect-uri: <%= protocol %>://support-signon.<%= dns %>
-        authorities: portal.users.read
-        access-token-validity: 1209600
-        refresh-token-validity: 1209600
-      oauth2service:
-        secret: <%= common_password %>
-        scope: openid,cloud_controller.read,cloud_controller.write
-        authorities: uaa.resource,oauth.service,clients.read,clients.write,clients.secret
-        authorized-grant-types: client_credentials,implicit
-        redirect-uri: <%= protocol %>://rewritten-later.cloudfoundry.com/whatever
-        override: true
-        autoapprove: true
       cf:
         override: true
         authorized-grant-types: password,implicit,refresh_token
@@ -417,14 +365,6 @@ properties:
         scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write
         access-token-validity: 7200
         refresh-token-validity: 1209600
-      servicesmgmt:
-        override: true
-        secret: <%= common_password %>
-        scope: openid,cloud_controller.read,cloud_controller.write
-        authorities: uaa.resource,oauth.service,clients.read,clients.write,clients.secret
-        authorized-grant-types: authorization_code,client_credentials,password,implicit
-        redirect-uri: <%= protocol %>://servicesmgmt.<%= dns %>/auth/cloudfoundry/callback
-        autoapprove: true
     scim:
       users:
       - admin|<%= common_password %>|scim.write,scim.read,openid,cloud_controller.admin

--- a/templates/v133/aws/medium/deployment_file.yml.erb
+++ b/templates/v133/aws/medium/deployment_file.yml.erb
@@ -312,18 +312,7 @@ properties:
     client:
       autoapprove:
         - cf
-        - my
-        - micro
-        - support-signon
     clients:
-      oauth2service:
-        secret: <%= common_password %>
-        scope: openid,cloud_controller.read,cloud_controller.write
-        authorities: uaa.resource,oauth.service,clients.read,clients.write,clients.secret
-        authorized-grant-types: client_credentials,implicit
-        redirect-uri: <%= protocol %>://rewritten-later.cloudfoundry.com/whatever
-        override: true
-        autoapprove: true
       cf:
         override: true
         authorized-grant-types: password,implicit,refresh_token
@@ -331,14 +320,6 @@ properties:
         scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write
         access-token-validity: 7200
         refresh-token-validity: 1209600
-      servicesmgmt:
-        override: true
-        secret: <%= common_password %>
-        scope: openid,cloud_controller.read,cloud_controller.write
-        authorities: uaa.resource,oauth.service,clients.read,clients.write,clients.secret
-        authorized-grant-types: authorization_code,client_credentials,password,implicit
-        redirect-uri: <%= protocol %>://servicesmgmt.mycloud.com/auth/cloudfoundry/callback
-        autoapprove: true
     scim:
       users:
       - admin|<%= common_password %>|scim.write,scim.read,openid,cloud_controller.admin

--- a/templates/v133/openstack/large/deployment_file.yml.erb
+++ b/templates/v133/openstack/large/deployment_file.yml.erb
@@ -68,7 +68,7 @@ update:
 resource_pools:
   - name: small
     network: default
-    size: 9
+    size: 8
     stemcell:
       name: bosh-stemcell
       version: latest
@@ -139,16 +139,6 @@ jobs:
     networks:
       - name: default
         default: [dns, gateway]           
-
-  - name: login
-    release: cf-release
-    template: 
-      - login
-    instances: 1
-    resource_pool: small
-    networks:
-      - name: default
-        default: [dns, gateway]
 
   - name: cloud_controller
     release: cf-release
@@ -239,19 +229,9 @@ properties:
 
   dea_next: *dea
 
-  service_lifecycle:
-    serialization_data_server:
-    - 169.254.1.1 
-
   syslog_aggregator:
     address: 0.syslog-aggregator.default.<%= name %>.microbosh
     port: 54321
-
-  serialization_data_server:
-    port: 8080
-    logging_level: debug
-    upload_token: <%= common_password %>
-    upload_timeout: 10
 
   nfs_server:
     address: 0.nfs-server.default.<%= name %>.microbosh
@@ -335,11 +315,7 @@ properties:
   ccng: *cc
 
   login:
-    protocol: <%= protocol %>
-    links:
-      home: <%= protocol %>://console.<%= dns %>
-      passwd: <%= protocol %>://console.<%= dns %>/password_resets/new
-      signup: <%= protocol %>://console.<%= dns %>/register
+    enabled: false
 
   uaa:
     url: <%= protocol %>://uaa.<%= dns %>
@@ -376,40 +352,12 @@ properties:
     admin:
       client_secret: <%= common_password %>
     batch:
-      username: batch
+      username: batchuser
       password: <%= common_password %>
     client:
       autoapprove:
         - cf
-        - my
-        - portal
-        - micro
-        - support-signon
-        - login
     clients:
-      login:
-        override: true
-        scope: openid
-        authorities: oauth.login
-        secret: <%= common_password %>
-        authorized-grant-types: authorization_code,client_credentials,refresh_token
-        redirect-uri: <%= protocol %>://login.<%= dns %>
-      support-services:
-        scope: scim.write,scim.read,openid,cloud_controller.read,cloud_controller.write
-        secret: <%= common_password %>
-        authorized-grant-types: authorization_code,client_credentials
-        redirect-uri: <%= protocol %>://support-signon.<%= dns %>
-        authorities: portal.users.read
-        access-token-validity: 1209600
-        refresh-token-validity: 1209600
-      oauth2service:
-        secret: <%= common_password %>
-        scope: openid,cloud_controller.read,cloud_controller.write
-        authorities: uaa.resource,oauth.service,clients.read,clients.write,clients.secret
-        authorized-grant-types: client_credentials,implicit
-        redirect-uri: <%= protocol %>://rewritten-later.cloudfoundry.com/whatever
-        override: true
-        autoapprove: true
       cf:
         override: true
         authorized-grant-types: password,implicit,refresh_token
@@ -417,14 +365,6 @@ properties:
         scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write
         access-token-validity: 7200
         refresh-token-validity: 1209600
-      servicesmgmt:
-        override: true
-        secret: <%= common_password %>
-        scope: openid,cloud_controller.read,cloud_controller.write
-        authorities: uaa.resource,oauth.service,clients.read,clients.write,clients.secret
-        authorized-grant-types: authorization_code,client_credentials,password,implicit
-        redirect-uri: <%= protocol %>://servicesmgmt.<%= dns %>/auth/cloudfoundry/callback
-        autoapprove: true
     scim:
       users:
       - admin|<%= common_password %>|scim.write,scim.read,openid,cloud_controller.admin

--- a/templates/v133/openstack/medium/deployment_file.yml.erb
+++ b/templates/v133/openstack/medium/deployment_file.yml.erb
@@ -312,18 +312,7 @@ properties:
     client:
       autoapprove:
         - cf
-        - my
-        - micro
-        - support-signon
     clients:
-      oauth2service:
-        secret: <%= common_password %>
-        scope: openid,cloud_controller.read,cloud_controller.write
-        authorities: uaa.resource,oauth.service,clients.read,clients.write,clients.secret
-        authorized-grant-types: client_credentials,implicit
-        redirect-uri: <%= protocol %>://rewritten-later.cloudfoundry.com/whatever
-        override: true
-        autoapprove: true
       cf:
         override: true
         authorized-grant-types: password,implicit,refresh_token
@@ -331,14 +320,6 @@ properties:
         scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write
         access-token-validity: 7200
         refresh-token-validity: 1209600
-      servicesmgmt:
-        override: true
-        secret: <%= common_password %>
-        scope: openid,cloud_controller.read,cloud_controller.write
-        authorities: uaa.resource,oauth.service,clients.read,clients.write,clients.secret
-        authorized-grant-types: authorization_code,client_credentials,password,implicit
-        redirect-uri: <%= protocol %>://servicesmgmt.mycloud.com/auth/cloudfoundry/callback
-        autoapprove: true
     scim:
       users:
       - admin|<%= common_password %>|scim.write,scim.read,openid,cloud_controller.admin

--- a/templates/v134/aws/large/deployment_file.yml.erb
+++ b/templates/v134/aws/large/deployment_file.yml.erb
@@ -68,7 +68,7 @@ update:
 resource_pools:
   - name: small
     network: default
-    size: 9
+    size: 8
     stemcell:
       name: bosh-stemcell
       version: latest
@@ -139,16 +139,6 @@ jobs:
     networks:
       - name: default
         default: [dns, gateway]           
-
-  - name: login
-    release: cf-release
-    template: 
-      - login
-    instances: 1
-    resource_pool: small
-    networks:
-      - name: default
-        default: [dns, gateway]
 
   - name: cloud_controller
     release: cf-release
@@ -239,19 +229,9 @@ properties:
 
   dea_next: *dea
 
-  service_lifecycle:
-    serialization_data_server:
-    - 169.254.1.1 
-
   syslog_aggregator:
     address: 0.syslog-aggregator.default.<%= name %>.microbosh
     port: 54321
-
-  serialization_data_server:
-    port: 8080
-    logging_level: debug
-    upload_token: <%= common_password %>
-    upload_timeout: 10
 
   nfs_server:
     address: 0.nfs-server.default.<%= name %>.microbosh
@@ -335,11 +315,7 @@ properties:
   ccng: *cc
 
   login:
-    protocol: <%= protocol %>
-    links:
-      home: <%= protocol %>://console.<%= dns %>
-      passwd: <%= protocol %>://console.<%= dns %>/password_resets/new
-      signup: <%= protocol %>://console.<%= dns %>/register
+    enabled: false
 
   uaa:
     url: <%= protocol %>://uaa.<%= dns %>
@@ -376,40 +352,12 @@ properties:
     admin:
       client_secret: <%= common_password %>
     batch:
-      username: batch
+      username: batchuser
       password: <%= common_password %>
     client:
       autoapprove:
         - cf
-        - my
-        - portal
-        - micro
-        - support-signon
-        - login
     clients:
-      login:
-        override: true
-        scope: openid
-        authorities: oauth.login
-        secret: <%= common_password %>
-        authorized-grant-types: authorization_code,client_credentials,refresh_token
-        redirect-uri: <%= protocol %>://login.<%= dns %>
-      support-services:
-        scope: scim.write,scim.read,openid,cloud_controller.read,cloud_controller.write
-        secret: <%= common_password %>
-        authorized-grant-types: authorization_code,client_credentials
-        redirect-uri: <%= protocol %>://support-signon.<%= dns %>
-        authorities: portal.users.read
-        access-token-validity: 1209600
-        refresh-token-validity: 1209600
-      oauth2service:
-        secret: <%= common_password %>
-        scope: openid,cloud_controller.read,cloud_controller.write
-        authorities: uaa.resource,oauth.service,clients.read,clients.write,clients.secret
-        authorized-grant-types: client_credentials,implicit
-        redirect-uri: <%= protocol %>://rewritten-later.cloudfoundry.com/whatever
-        override: true
-        autoapprove: true
       cf:
         override: true
         authorized-grant-types: password,implicit,refresh_token
@@ -417,14 +365,6 @@ properties:
         scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write
         access-token-validity: 7200
         refresh-token-validity: 1209600
-      servicesmgmt:
-        override: true
-        secret: <%= common_password %>
-        scope: openid,cloud_controller.read,cloud_controller.write
-        authorities: uaa.resource,oauth.service,clients.read,clients.write,clients.secret
-        authorized-grant-types: authorization_code,client_credentials,password,implicit
-        redirect-uri: <%= protocol %>://servicesmgmt.<%= dns %>/auth/cloudfoundry/callback
-        autoapprove: true
     scim:
       users:
       - admin|<%= common_password %>|scim.write,scim.read,openid,cloud_controller.admin

--- a/templates/v134/aws/medium/deployment_file.yml.erb
+++ b/templates/v134/aws/medium/deployment_file.yml.erb
@@ -312,18 +312,7 @@ properties:
     client:
       autoapprove:
         - cf
-        - my
-        - micro
-        - support-signon
     clients:
-      oauth2service:
-        secret: <%= common_password %>
-        scope: openid,cloud_controller.read,cloud_controller.write
-        authorities: uaa.resource,oauth.service,clients.read,clients.write,clients.secret
-        authorized-grant-types: client_credentials,implicit
-        redirect-uri: <%= protocol %>://rewritten-later.cloudfoundry.com/whatever
-        override: true
-        autoapprove: true
       cf:
         override: true
         authorized-grant-types: password,implicit,refresh_token
@@ -331,14 +320,6 @@ properties:
         scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write
         access-token-validity: 7200
         refresh-token-validity: 1209600
-      servicesmgmt:
-        override: true
-        secret: <%= common_password %>
-        scope: openid,cloud_controller.read,cloud_controller.write
-        authorities: uaa.resource,oauth.service,clients.read,clients.write,clients.secret
-        authorized-grant-types: authorization_code,client_credentials,password,implicit
-        redirect-uri: <%= protocol %>://servicesmgmt.mycloud.com/auth/cloudfoundry/callback
-        autoapprove: true
     scim:
       users:
       - admin|<%= common_password %>|scim.write,scim.read,openid,cloud_controller.admin

--- a/templates/v134/openstack/large/deployment_file.yml.erb
+++ b/templates/v134/openstack/large/deployment_file.yml.erb
@@ -68,7 +68,7 @@ update:
 resource_pools:
   - name: small
     network: default
-    size: 9
+    size: 8
     stemcell:
       name: bosh-stemcell
       version: latest
@@ -139,16 +139,6 @@ jobs:
     networks:
       - name: default
         default: [dns, gateway]           
-
-  - name: login
-    release: cf-release
-    template: 
-      - login
-    instances: 1
-    resource_pool: small
-    networks:
-      - name: default
-        default: [dns, gateway]
 
   - name: cloud_controller
     release: cf-release
@@ -239,19 +229,9 @@ properties:
 
   dea_next: *dea
 
-  service_lifecycle:
-    serialization_data_server:
-    - 169.254.1.1 
-
   syslog_aggregator:
     address: 0.syslog-aggregator.default.<%= name %>.microbosh
     port: 54321
-
-  serialization_data_server:
-    port: 8080
-    logging_level: debug
-    upload_token: <%= common_password %>
-    upload_timeout: 10
 
   nfs_server:
     address: 0.nfs-server.default.<%= name %>.microbosh
@@ -335,11 +315,7 @@ properties:
   ccng: *cc
 
   login:
-    protocol: <%= protocol %>
-    links:
-      home: <%= protocol %>://console.<%= dns %>
-      passwd: <%= protocol %>://console.<%= dns %>/password_resets/new
-      signup: <%= protocol %>://console.<%= dns %>/register
+    enabled: false
 
   uaa:
     url: <%= protocol %>://uaa.<%= dns %>
@@ -376,40 +352,12 @@ properties:
     admin:
       client_secret: <%= common_password %>
     batch:
-      username: batch
+      username: batchuser
       password: <%= common_password %>
     client:
       autoapprove:
         - cf
-        - my
-        - portal
-        - micro
-        - support-signon
-        - login
     clients:
-      login:
-        override: true
-        scope: openid
-        authorities: oauth.login
-        secret: <%= common_password %>
-        authorized-grant-types: authorization_code,client_credentials,refresh_token
-        redirect-uri: <%= protocol %>://login.<%= dns %>
-      support-services:
-        scope: scim.write,scim.read,openid,cloud_controller.read,cloud_controller.write
-        secret: <%= common_password %>
-        authorized-grant-types: authorization_code,client_credentials
-        redirect-uri: <%= protocol %>://support-signon.<%= dns %>
-        authorities: portal.users.read
-        access-token-validity: 1209600
-        refresh-token-validity: 1209600
-      oauth2service:
-        secret: <%= common_password %>
-        scope: openid,cloud_controller.read,cloud_controller.write
-        authorities: uaa.resource,oauth.service,clients.read,clients.write,clients.secret
-        authorized-grant-types: client_credentials,implicit
-        redirect-uri: <%= protocol %>://rewritten-later.cloudfoundry.com/whatever
-        override: true
-        autoapprove: true
       cf:
         override: true
         authorized-grant-types: password,implicit,refresh_token
@@ -417,14 +365,6 @@ properties:
         scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write
         access-token-validity: 7200
         refresh-token-validity: 1209600
-      servicesmgmt:
-        override: true
-        secret: <%= common_password %>
-        scope: openid,cloud_controller.read,cloud_controller.write
-        authorities: uaa.resource,oauth.service,clients.read,clients.write,clients.secret
-        authorized-grant-types: authorization_code,client_credentials,password,implicit
-        redirect-uri: <%= protocol %>://servicesmgmt.<%= dns %>/auth/cloudfoundry/callback
-        autoapprove: true
     scim:
       users:
       - admin|<%= common_password %>|scim.write,scim.read,openid,cloud_controller.admin

--- a/templates/v134/openstack/medium/deployment_file.yml.erb
+++ b/templates/v134/openstack/medium/deployment_file.yml.erb
@@ -312,18 +312,7 @@ properties:
     client:
       autoapprove:
         - cf
-        - my
-        - micro
-        - support-signon
     clients:
-      oauth2service:
-        secret: <%= common_password %>
-        scope: openid,cloud_controller.read,cloud_controller.write
-        authorities: uaa.resource,oauth.service,clients.read,clients.write,clients.secret
-        authorized-grant-types: client_credentials,implicit
-        redirect-uri: <%= protocol %>://rewritten-later.cloudfoundry.com/whatever
-        override: true
-        autoapprove: true
       cf:
         override: true
         authorized-grant-types: password,implicit,refresh_token
@@ -331,14 +320,6 @@ properties:
         scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write
         access-token-validity: 7200
         refresh-token-validity: 1209600
-      servicesmgmt:
-        override: true
-        secret: <%= common_password %>
-        scope: openid,cloud_controller.read,cloud_controller.write
-        authorities: uaa.resource,oauth.service,clients.read,clients.write,clients.secret
-        authorized-grant-types: authorization_code,client_credentials,password,implicit
-        redirect-uri: <%= protocol %>://servicesmgmt.mycloud.com/auth/cloudfoundry/callback
-        autoapprove: true
     scim:
       users:
       - admin|<%= common_password %>|scim.write,scim.read,openid,cloud_controller.admin


### PR DESCRIPTION
Until there is a reasonable way to configure it, removing login job.

Also, cleaning out unused internal oauth credentials
