### PR TITLE
Must provide syslog properties even if disabled [fixes #215]

### DIFF
--- a/spec/assets/v133/aws/medium.yml
+++ b/spec/assets/v133/aws/medium.yml
@@ -151,6 +151,10 @@ properties:
 
   dea_next: *dea
 
+  syslog_aggregator:
+    address: 0.syslog-aggregator.default.demo.microbosh
+    port: 54321
+
   nfs_server:
     address: 0.data.default.demo.microbosh
     #network: "*.demo.microbosh"

--- a/templates/v133/aws/medium/deployment_file.yml.erb
+++ b/templates/v133/aws/medium/deployment_file.yml.erb
@@ -188,6 +188,10 @@ properties:
 
   dea_next: *dea
 
+  syslog_aggregator:
+    address: 0.syslog-aggregator.default.<%= name %>.microbosh
+    port: 54321
+
   nfs_server:
     address: 0.data.default.<%= name %>.microbosh
     #network: "*.<%= name %>.microbosh"

--- a/templates/v133/openstack/medium/deployment_file.yml.erb
+++ b/templates/v133/openstack/medium/deployment_file.yml.erb
@@ -188,6 +188,10 @@ properties:
 
   dea_next: *dea
 
+  syslog_aggregator:
+    address: 0.syslog-aggregator.default.<%= name %>.microbosh
+    port: 54321
+
   nfs_server:
     address: 0.data.default.<%= name %>.microbosh
     #network: "*.<%= name %>.microbosh"

--- a/templates/v134/aws/medium/deployment_file.yml.erb
+++ b/templates/v134/aws/medium/deployment_file.yml.erb
@@ -188,6 +188,10 @@ properties:
 
   dea_next: *dea
 
+  syslog_aggregator:
+    address: 0.syslog-aggregator.default.<%= name %>.microbosh
+    port: 54321
+
   nfs_server:
     address: 0.data.default.<%= name %>.microbosh
     #network: "*.<%= name %>.microbosh"

--- a/templates/v134/openstack/medium/deployment_file.yml.erb
+++ b/templates/v134/openstack/medium/deployment_file.yml.erb
@@ -188,6 +188,10 @@ properties:
 
   dea_next: *dea
 
+  syslog_aggregator:
+    address: 0.syslog-aggregator.default.<%= name %>.microbosh
+    port: 54321
+
   nfs_server:
     address: 0.data.default.<%= name %>.microbosh
     #network: "*.<%= name %>.microbosh"


### PR DESCRIPTION
Until https://github.com/cloudfoundry/cf-release/pull/113 is merged, we must provide
`properties.syslog_aggregator.host` even if its not enabled; otherwise bosh
may not be able to apply templates.
