### PR TITLE
Doesn't work on Windows

### DIFF
--- a/tutorials/build-your-own-heroku-with-cloudfoundry.md
+++ b/tutorials/build-your-own-heroku-with-cloudfoundry.md
@@ -9,6 +9,7 @@ There are some requirements:
 * AWS account, with access credentials, and capacity to provision 6 servers & 2 elastic IPs
 * Credit on the credit card attached to your AWS account for $1 or so
 * Ruby 1.9.3 or Ruby 2.0.0 installed on your local machine
+* Git (1.8+) installed on your local machine
 * Internet access
 * About an hour of your time (about 5 minutes of your human activity)
 * Possibly doesn't support Windows (please let me know if you have any success or failure)

--- a/tutorials/build-your-own-heroku-with-cloudfoundry.md
+++ b/tutorials/build-your-own-heroku-with-cloudfoundry.md
@@ -12,7 +12,7 @@ There are some requirements:
 * Git (1.8+) installed on your local machine
 * Internet access
 * About an hour of your time (about 5 minutes of your human activity)
-* Possibly doesn't support Windows (please let me know if you have any success or failure)
+* Doesn't support Windows (lack of rsync for windows)
 
 Optionally:
 


### PR DESCRIPTION
@drnic - Just tried running through this tutorial from a Windows (2012 server) instance, and unfortunately it doesn't work due to a lack of a decent rsync Windows port.  Full error below.

A better bet is to probably start with a local Vagrant Ubuntu box.

```
Booting m1.small inception server... i-84343ab9
Confirming ssh access to server... done
Provisioning 16Gb persistent disk for inception server... i-84343ab9

Prepare inception server

knife solo prepare ubuntu@ec2-54-253-19-66.ap-southeast-2.compute.amazonaws.com -i C:/Users/mrdavidlaing/.inception_serv
er/ssh/inception -j '{"disk":{"mounted":true,"device":"/dev/xvdf"},"git":{"name":"David Laing","email":"david@davidlaing
.com"},"user":{"username":"ubuntu"},"fog":{"aws_access_key_id":"AKIAIATGPH3YNTXCJ72A","aws_secret_access_key":"oF8S8UQ2X
4jJ8hI0IrBwwKIapbt8ef/zNsStsS0o"}}' -r 'bosh_inception'
WARNING: No knife configuration file found
Bootstrapping Chef...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  6516  100  6516    0     0   6377      0  0:00:01  0:00:01 --:--:--  6413
Downloading Chef 11.4.4 for ubuntu...
Installing Chef 11.4.4
Selecting previously unselected package chef.
(Reading database ... 52215 files and directories currently installed.)
Unpacking chef (from .../chef_11.4.4_amd64.deb) ...
Setting up chef (11.4.4-2.ubuntu.11.04) ...
Thank you for installing Chef!
Generating node config 'nodes/ec2-54-253-19-66.ap-southeast-2.compute.amazonaws.com.json'...
knife solo cook ubuntu@ec2-54-253-19-66.ap-southeast-2.compute.amazonaws.com -i C:/Users/mrdavidlaing/.inception_server/
ssh/inception -j '{"disk":{"mounted":true,"device":"/dev/xvdf"},"git":{"name":"David Laing","email":"david@davidlaing.co
m"},"user":{"username":"ubuntu"},"fog":{"aws_access_key_id":"AKIAIATGPH3YNTXCJ72A","aws_secret_access_key":"oF8S8UQ2X4jJ
8hI0IrBwwKIapbt8ef/zNsStsS0o"}}' -r 'bosh_inception'
WARNING: No knife configuration file found
Running Chef on ec2-54-253-19-66.ap-southeast-2.compute.amazonaws.com...
Checking Chef version...
WARNING: Berkshelf could not be loaded
WARNING: Please add the berkshelf gem to your Gemfile or install it manually with `gem install berkshelf`
Uploading the kitchen...
WARNING: Local cookbook_path 'C:/chef/cookbooks' does not exist
WARNING: Local cookbook_path 'C:/chef/site-cookbooks' does not exist
ERROR: RuntimeError: Failed to launch command rsync -rl  --chmod=ugo=rwX --rsh="ssh ubuntu@ec2-54-253-19-66.ap-southeast
-2.compute.amazonaws.com -i C:/Users/mrdavidlaing/.inception_server/ssh/inception" --delete --exclude 'revision-deploys'
 --exclude 'tmp' --exclude '.git' --exclude '.hg' --exclude '.svn' --exclude '.bzr' /cygdrive/C/Ruby193/lib/ruby/gems/1.
9.1/gems/knife-solo-0.3.0.pre5/lib/knife-solo/resources/patch_cookbooks/ :~/chef-solo/cookbooks-3
C:/Ruby193/lib/ruby/1.9.1/rake/file_utils.rb:53:in `block in create_shell_runner': Command failed with status (100): [kn
ife solo cook ubuntu@ec2-54-253-19-66.ap...] (RuntimeError)
        from C:/Ruby193/lib/ruby/1.9.1/rake/file_utils.rb:45:in `call'
        from C:/Ruby193/lib/ruby/1.9.1/rake/file_utils.rb:45:in `sh'
        from C:/Ruby193/lib/ruby/gems/1.9.1/gems/inception-server-0.2.1/lib/inception/inception_server_cookbook.rb:39:in
 `knife_solo'
        from C:/Ruby193/lib/ruby/gems/1.9.1/gems/inception-server-0.2.1/lib/inception/inception_server_cookbook.rb:26:in
 `block in converge'
        from C:/Ruby193/lib/ruby/1.9.1/fileutils.rb:125:in `chdir'
        from C:/Ruby193/lib/ruby/1.9.1/fileutils.rb:125:in `cd'
        from C:/Ruby193/lib/ruby/gems/1.9.1/gems/inception-server-0.2.1/lib/inception/inception_server_cookbook.rb:25:in
 `converge'
        from C:/Ruby193/lib/ruby/gems/1.9.1/gems/inception-server-0.2.1/lib/inception/cli.rb:112:in `converge_cookbooks'

        from C:/Ruby193/lib/ruby/gems/1.9.1/gems/inception-server-0.2.1/lib/inception/cli.rb:35:in `deploy'
        from C:/Ruby193/lib/ruby/gems/1.9.1/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
        from C:/Ruby193/lib/ruby/gems/1.9.1/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
        from C:/Ruby193/lib/ruby/gems/1.9.1/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
        from C:/Ruby193/lib/ruby/gems/1.9.1/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
        from C:/Ruby193/lib/ruby/gems/1.9.1/gems/inception-server-0.2.1/bin/inception:8:in `<top (required)>'
        from C:/Ruby193/bin/inception:23:in `load'
        from C:/Ruby193/bin/inception:23:in `<main>'
```
