### PR TITLE
Add v136 release

### DIFF
--- a/bosh_release/.final_builds/jobs/cloud_controller_ng/index.yml
+++ b/bosh_release/.final_builds/jobs/cloud_controller_ng/index.yml
@@ -34,3 +34,13 @@ builds:
     version: 8
     sha1: !binary |-
       Y2U2MjQ5MDUyMzA4ZmZjZDQ5ZDcwYTAxNTI5ZmJiNmE5NjY2NTg1MQ==
+  !binary "MTdhM2MyZjc4YWVlNzIxZTI4MjZkMGFjYTFkYzUxNGE3NmY3ZGNlOA==":
+    blobstore_id: 194d9e55-ab4a-45c7-998b-d03062d2bcac
+    version: 9
+    sha1: !binary |-
+      YTg0ZjAyNGU1YjRhMzY1OGM3ZGU3MDAyNWU1MGNkZTUzYzgzYzliMQ==
+  !binary "YTYzNzUwNTI5YmYxOWY4YzBiMGY2OWJmN2Q4ZjY0OGFhZmVlYzI4Yw==":
+    blobstore_id: 386f1580-3588-4361-8e69-573a56698f9f
+    version: 10
+    sha1: !binary |-
+      NzkzODIzZGVlNDJlM2RkOThjMDk1NDQ2NGIxYzZlNDg1YTYzOGUxZg==

--- a/bosh_release/.final_builds/jobs/dea_logging_agent/index.yml
+++ b/bosh_release/.final_builds/jobs/dea_logging_agent/index.yml
@@ -1,0 +1,7 @@
+---
+builds:
+  !binary "YzU3MTU4M2E5YTVhNDg2MjQ0YzI2MDA5NDEyZDlkYjBlNjM2YjdmOA==":
+    blobstore_id: 6420dc76-30e9-47ad-8582-21f877cb88d4
+    version: 1
+    sha1: !binary |-
+      ZGI5MzJmOWFhZTNlOTg0NjhhODA0ZjUwMDc1NTg0MzBmYmZmYjk5Mg==

--- a/bosh_release/.final_builds/jobs/dea_next/index.yml
+++ b/bosh_release/.final_builds/jobs/dea_next/index.yml
@@ -54,3 +54,8 @@ builds:
     version: 13
     sha1: !binary |-
       YWFhMjYxZjI3MGZlMjY5OTk2MWRjMzZlMjAzOWJkNTBjZjdhMGM2Mg==
+  !binary "Yjg3ODUyYTdkYzQ5NDNmYmRlODc5NmQ0MmM2MjQ4M2QxNmIzOWM3Yg==":
+    blobstore_id: 5e95f5cc-9064-4d14-afa1-7074cb6682ef
+    version: 14
+    sha1: !binary |-
+      YjRkMjI5ZDQ5NTRjNGY5N2RkYTJlOWYxMWVhZjU0ODgyNDMxNjMyOQ==

--- a/bosh_release/.final_builds/jobs/health_manager_next/index.yml
+++ b/bosh_release/.final_builds/jobs/health_manager_next/index.yml
@@ -34,3 +34,8 @@ builds:
     version: 8
     sha1: !binary |-
       OTQxZjNjYWZkZmNhZDliNWE2MzdjODVhNjZiZTAwYjc4Y2MzZDY0MQ==
+  !binary "NWM2OGU1YzEwOTk5NGYwMWZhYmVkYmFjMjA4NTBkOTU3NzEzYzBmZQ==":
+    blobstore_id: eea44df6-1342-4087-9d4b-b16447f982c3
+    version: 9
+    sha1: !binary |-
+      YzBhZGJmZmZlYWM2ZGQ2NmY0ZTA1NDRhMThjNjYwZDBjNDEyMTMxNQ==

--- a/bosh_release/.final_builds/jobs/loggregator/index.yml
+++ b/bosh_release/.final_builds/jobs/loggregator/index.yml
@@ -1,0 +1,7 @@
+---
+builds:
+  !binary "Mzc4OTEyNzljOGE0ZWM4NDNiNWZiMmEyMWIxNDZiMGE4NWNiNmZlZg==":
+    blobstore_id: b63b5650-5c96-4c70-a4db-ee631c03112e
+    version: 1
+    sha1: !binary |-
+      ZGE5YTdlMGFkZTU2YTFmNWQ5ZTA4ZTE1ZTJlZWMxOWM5ODgwNDljOQ==

--- a/bosh_release/.final_builds/jobs/login/index.yml
+++ b/bosh_release/.final_builds/jobs/login/index.yml
@@ -55,3 +55,13 @@ builds:
     version: 13
     sha1: !binary |-
       ZjdmMDcxNzg0ZTg1NGNhZjlkMWI0MTI1MzdjNmE5MzI5MzY0ZjlmNQ==
+  !binary "NzU3NTg2OTFhODI3NmJmMjhiOTUxODZkNWIxYTE5ZGY2Zjg5NjFhYQ==":
+    blobstore_id: 6fac573a-2689-4276-ba4f-351dbe125b13
+    version: 14
+    sha1: !binary |-
+      NjA0Y2ZiOWI0ZWM1YTZiYjViZmNkNzQ0ZWE0NzViNmRiZmQyMTNhNg==
+  !binary "ZTZhN2UwN2JlZWM0OGI4NTQ2OTI0ZDVmNDNmMGFlYzY2Y2U2YTJlYw==":
+    blobstore_id: 6f4d233f-bf03-4164-b0fa-bf0446a20279
+    version: 15
+    sha1: !binary |-
+      MjhkOTAyZjVlYjVlNGE3OTAwZjExZDQxMTJmZjZkZDU0Mjk2NmU0OA==

--- a/bosh_release/.final_builds/jobs/saml_login/index.yml
+++ b/bosh_release/.final_builds/jobs/saml_login/index.yml
@@ -5,3 +5,13 @@ builds:
     version: 1
     sha1: !binary |-
       MjhiOGRiNWZjMjUzMGU3YzNkYWUwOTZiZWI0M2Y5ZTg0NzU5NTkyYw==
+  !binary "MmZiZTZhNzQwNjJhNjkxOWM3OTkxZjQwODRjYTFlMDg2OGI2MGU2NQ==":
+    blobstore_id: 6909cb27-58cb-45e8-ac39-ae31e92182f9
+    version: 2
+    sha1: !binary |-
+      ZjA3N2UyZWQ5NzI1Y2VlMWIyMzJmMjU2MDRkNDE0NDQ3ODllMzA5Zg==
+  !binary "MGQ4MTE4YjQzOWExNzAzYjQ0ZTZjMDJkODE0NTk3ZTFlZTg3MTU0OA==":
+    blobstore_id: 1eca2d72-de4e-4c76-9570-6c9d3fa8d601
+    version: 3
+    sha1: !binary |-
+      YTU5Y2JmMmJlNmYwYzllNzM1OWVlNjYwMzUwZTE1NDlmZDllZGZiNA==

--- a/bosh_release/.final_builds/jobs/syslog_aggregator/index.yml
+++ b/bosh_release/.final_builds/jobs/syslog_aggregator/index.yml
@@ -46,3 +46,8 @@ builds:
     version: 11
     sha1: !binary |-
       OWM0MjQwYjFlNzRhZDg5MGNmNTUxMjI5ODhmMjQ5NzAwODY3M2ZmYQ==
+  !binary "ODRmNzBlNTA2YzAxYTVmMTcxZjM5MmQwMTQ4MWFhMzE0MTUxNDA3OA==":
+    blobstore_id: 4c65b7a6-3891-42e9-ade1-71f0df4aa317
+    version: 12
+    sha1: !binary |-
+      MTQxYzE4ZGEzNDU2OWZmYmEzMWMxMWVjZjQ5OTQ2ZjJkM2E2ZTY1Ng==

--- a/bosh_release/.final_builds/jobs/uaa/index.yml
+++ b/bosh_release/.final_builds/jobs/uaa/index.yml
@@ -114,3 +114,8 @@ builds:
     version: 28
     sha1: !binary |-
       MmUxMWMzNGYwYWQwMDcwNmIwMzUxYmE4NzBlOTlhZTI4NDYxNDU4OA==
+  !binary "ODI2YjYzMDE5ZmVhOWFlYWZjNGFkNTNjMmNiZmZiMTY2ZmY4OTkwZQ==":
+    blobstore_id: 518d9f5c-4cca-4548-85c6-7db9429ea4db
+    version: 29
+    sha1: !binary |-
+      NTMzOTRlNDgxZmFiODk5N2QzYjY2NzM4MTA1MDUyMzIzYmMxYjZlMA==

--- a/bosh_release/.final_builds/packages/cfop/index.yml
+++ b/bosh_release/.final_builds/packages/cfop/index.yml
@@ -1,0 +1,7 @@
+---
+builds:
+  !binary "ZTk1OWE1YmJmMDhkYzRlZjU3ZDM3NWQ1MmM0Y2E1MDU0MDcwZmFmNA==":
+    blobstore_id: 4904761d-dd47-4770-baae-3aa919ffa190
+    version: 1
+    sha1: !binary |-
+      ZjEzY2QzNTdkOGUzNzVkNjM4YmViOGM0MGY5YzEwMWUyMjVkYmJhYQ==

--- a/bosh_release/.final_builds/packages/cloud_controller_ng/index.yml
+++ b/bosh_release/.final_builds/packages/cloud_controller_ng/index.yml
@@ -63,3 +63,13 @@ builds:
     version: 15
     sha1: !binary |-
       MzNkOWNlNzljN2VkNWZmMzRlNmYwZjYxY2I3NjIyYWRlZmM3NjNlMQ==
+  !binary "MGYxYWFkYzZlNDFhNDZmNzlkNTBkNjE1MmZmMjczNzg5ZjcyM2I2MA==":
+    blobstore_id: d19a8e25-895e-4e75-95c8-235af86b65f5
+    version: 16
+    sha1: !binary |-
+      ZWEzZWJkMmRjZjA0MjBiNzYxYmZmNGExZWMxNjYyNTBhMDBhYzhkNQ==
+  !binary "ZGU1MjVkY2E4OGZlN2M3YjYxODZjZTI3MTQ5YzJlYTgyYTFmZjBlYQ==":
+    blobstore_id: 3751807a-ae66-472b-86f0-2b9d141c0e1e
+    version: 17
+    sha1: !binary |-
+      NmIxMDVhOThhOTcwNmMxZjk0MWNmNzZlMTNkMzAyYzdmMGI1NzQyZA==

--- a/bosh_release/.final_builds/packages/collector/index.yml
+++ b/bosh_release/.final_builds/packages/collector/index.yml
@@ -38,3 +38,13 @@ builds:
     version: 9
     sha1: !binary |-
       YWM3OTgyNzlhZmM0MDkxOTE2YjA1NTMwMDg1MWRjN2E3NDVmYWI5Mw==
+  !binary "MWQyMDAxNDc4NzUxMDQzNzNiZDQxMGJlNzRmYTExNDE5NDQzYjFkNg==":
+    blobstore_id: d8e60e7f-0185-41e7-8616-042c0e37812c
+    version: 10
+    sha1: !binary |-
+      N2FkOGQ5YzI2MmEwYzZlMTkxN2Q2ZTEzMzM5NzcyODZiZjhmOGNmOA==
+  !binary "YTg4MTUyZWZlMmFlNzFhODUxNzI0MDk5NTIzZjI0OTYxZjQzODBmOA==":
+    blobstore_id: f9dccb94-57eb-4903-989d-a5c905bb34b9
+    version: 11
+    sha1: !binary |-
+      NGRkZmIwMTk3YWRmYWE4ZmY0ZDIxNjZjNmM1ODVjMGVkNWIxNGQzMQ==

--- a/bosh_release/.final_builds/packages/dashboard/index.yml
+++ b/bosh_release/.final_builds/packages/dashboard/index.yml
@@ -57,3 +57,8 @@ builds:
     version: 14
     sha1: !binary |-
       YzY3ODE3ZjE0Y2Y3YmI2YjY3OTdlOTkyMTcwNTUyOTA5ZjYzMzQ2OA==
+  !binary "YTgwNmU2YWI5NmRiMjZlMzNlNjdjYTc4MTE1ZTQzOGIyMzA3YzA1Yw==":
+    blobstore_id: 495cb60a-d80a-41f5-a7bb-6bd4460cc74b
+    version: 15
+    sha1: !binary |-
+      ZWU0YzA3MzA2ZTAxZWI3OGU2ZDY4YTRkOTZiNzVjNjg4NDdiMTZmNQ==

--- a/bosh_release/.final_builds/packages/dea_logging_agent/index.yml
+++ b/bosh_release/.final_builds/packages/dea_logging_agent/index.yml
@@ -1,0 +1,7 @@
+---
+builds:
+  !binary "NmNhZWJiYzliNzRkY2RjMjIzNDM2MGFlYjM0NzNiMjlkNGM0NjI1OA==":
+    blobstore_id: b5faa8c5-e54f-4d3d-bf2d-6a5861db1d69
+    version: 1
+    sha1: !binary |-
+      YWZhYzE5ZTlkYTBiYjA3ZTc2Mzc4YWM2YjViYjIxY2ZkYzZjMjlkYg==

--- a/bosh_release/.final_builds/packages/dea_next/index.yml
+++ b/bosh_release/.final_builds/packages/dea_next/index.yml
@@ -75,3 +75,13 @@ builds:
     version: 18
     sha1: !binary |-
       YTJhZDQ3ODkyYjg5MmU5OWNlYmIxYzM2M2MyM2UzOWFmYTk4ZDI5MA==
+  !binary "MzYxZjRkYzY0ZmQzY2ZjMzcyMjhiYmQ3MTU0NjllOWNjZDU5ZWIxNA==":
+    blobstore_id: b0b13196-2a15-4e3e-bc64-ade869c81002
+    version: 19
+    sha1: !binary |-
+      MjQ5MzcwOTA1YmZlMDcxNzZkYzA0NDkzNTVkODkwODBiMWVkY2JmNQ==
+  !binary "MzBkYjY1MGNiZGNjNTRlYjk1ZmYzZDgxYWQxMTIzZGMyY2JlZTY3Mw==":
+    blobstore_id: f0d1fc8c-f5d8-4a42-a25a-50b7ff467688
+    version: 20
+    sha1: !binary |-
+      OWJmZGYxZTEzYTEwNTVkY2QwOGQwZmNjMGY0ZGQ1ZDZlYzI2ZDE0MQ==

--- a/bosh_release/.final_builds/packages/gorouter/index.yml
+++ b/bosh_release/.final_builds/packages/gorouter/index.yml
@@ -27,3 +27,13 @@ builds:
     version: 6
     sha1: !binary |-
       YmE1OTgxOWU4MTRhZTQ2OWE0MmVlZDQ3N2MxYzI1MWE0NzFlZGUwNA==
+  !binary "Mzk5MDYxODg3MjY5YWYxM2Q2MmEwNzUyYzIxZjQ5NGMxMTRjMDY2ZA==":
+    blobstore_id: 34dcd257-8542-4d30-ab2a-57be663c8e85
+    version: 7
+    sha1: !binary |-
+      MmMwMDQ0YzU1OTExY2RlZmJmNDA2ZTk5MjFiNDYyZTQ4NmJjNDUyNg==
+  !binary "NjY2MTJlYTE3MTA2MzIyNWRiN2Q4YTQzNTI4OTYwZjFhYzBjNTM1Ng==":
+    blobstore_id: 718b251d-fb8d-4acc-acaa-2fb80e078e48
+    version: 8
+    sha1: !binary |-
+      NmJjODgwZWMzOTQwOTcyZDNjYjViNmZjMmViNTNmNzAyZTlmOTVlMg==

--- a/bosh_release/.final_builds/packages/health_manager_next/index.yml
+++ b/bosh_release/.final_builds/packages/health_manager_next/index.yml
@@ -73,3 +73,13 @@ builds:
     version: 18
     sha1: !binary |-
       NTRlMTg0NDFhNGQwODFmNjFkOWE4MzU3NGUzMGMxZTQxYzM2ZTRjMA==
+  !binary "NzZmNDI2NGE4NGMyMjBlM2NjMWQ0YjQ0NTljNjhlMWM0OTY0MGNmMg==":
+    blobstore_id: 374b3c76-6dfe-4e4e-8e66-0268b8808e43
+    version: 19
+    sha1: !binary |-
+      M2ZhZDMxOGQzYTM3YWUyM2IyYzY1NTg1YTVmZTJlYWEzZTA2YjIyZA==
+  !binary "NTY0OWU3MTBmNGQ4YzRjY2RiNGZlYWNhMjc0OTZmZWNjNjJlMDY4OA==":
+    blobstore_id: eaf4f608-9a60-4060-8047-1aa8a40e0e6b
+    version: 20
+    sha1: !binary |-
+      YzQ2ZGJlNjM0NmRmY2I5ZmViY2Y5MDYyYTM3ZThjZDMyYzJjYTE0Mg==

--- a/bosh_release/.final_builds/packages/loggregator/index.yml
+++ b/bosh_release/.final_builds/packages/loggregator/index.yml
@@ -1,0 +1,7 @@
+---
+builds:
+  !binary "ZmI1YWJkZDU3NTA3YTIyN2RhN2Q2ZWYwOGEzNWVmZTkwZWViZmI4Yg==":
+    blobstore_id: c3402145-8cf7-4c72-988b-fd7a88027727
+    version: 1
+    sha1: !binary |-
+      YTM0ZWI0MGIyMjQ2NGExNjAyNTM0ZmIzNDI2N2Q2N2VkMDdlMzNiOA==

--- a/bosh_release/.final_builds/packages/login/index.yml
+++ b/bosh_release/.final_builds/packages/login/index.yml
@@ -63,3 +63,13 @@ builds:
     version: 15
     sha1: !binary |-
       MGM5ZGMwZGZhNzJhOTI2OTg5OWVlZDM4NTg2NDk5Y2UzNjc2MTg1OQ==
+  !binary "YTA5MzQ0ZTAzNGQ4Y2NiMDg1ODcxMWI2YWI1ZDExNWI1MzcwMTg3ZQ==":
+    blobstore_id: 77ff577f-f7a2-4938-b65a-35c6bb6995b8
+    version: 16
+    sha1: !binary |-
+      OTJiMTMzMjk4ZDk3ZTIwMzQ2ZjMyOGEwODZiZjc3NTkyODcyMDY0Yw==
+  !binary "MzBkY2ZlOWM3ZTI0MzdiZjYzYzNjNDJhOTUxOTEwYzU3MjQxYTgxYg==":
+    blobstore_id: 131631bd-3175-40d8-870d-0f851b38afb8
+    version: 17
+    sha1: !binary |-
+      OTBmM2RkMGY0NjVkZjM5MGIwMGM0MmZhZWI5MjliMzFjYzdmZjZmOQ==

--- a/bosh_release/.final_builds/packages/ruby/index.yml
+++ b/bosh_release/.final_builds/packages/ruby/index.yml
@@ -33,3 +33,8 @@ builds:
     version: 8
     sha1: !binary |-
       ZGI3MmVlNWI5Yjg1OGIwNGYyOTBiZTdiOTVhNzViZDY4YzZkYWFkMg==
+  !binary "MGNlZTMwYTYwNmQ4NjI3NzdmYWY4NDZhYzQ4NDhjZTE4NjY1YzA5OQ==":
+    blobstore_id: dd1a3f29-3ba3-4a6b-8dc3-f2b0e91de4f8
+    version: 9
+    sha1: !binary |-
+      NGNmNmMxYWFmOTdjZTU3MjkyYzE2ZDBiOGVkNTBhZTc4MDBkYWY2Yg==

--- a/bosh_release/.final_builds/packages/saml_login/index.yml
+++ b/bosh_release/.final_builds/packages/saml_login/index.yml
@@ -5,3 +5,13 @@ builds:
     version: 1
     sha1: !binary |-
       NWM4NGMyNmYyNDhlYjYzNTIwNWE1YjM2YWRiMzM1ZWU5ZTc3NzVjYg==
+  !binary "NjU2MzA2MjY3YjYzNTA0MzJjZWYwNDFkZjk3ZjU4N2MzODY2YmRmYg==":
+    blobstore_id: 9430b61d-494c-4ae8-8ce4-e58df95ae9e9
+    version: 2
+    sha1: !binary |-
+      MTMyNTlkOTdhZmIxNmFlZjBhOGNmMDY1Y2NlMGFmMDAxOWU5YzU5YQ==
+  !binary "ZWMzMTEyZTljZTEyOGJkYzIxMzFhYmJmM2IxYjg5YTIzNGNhYWFkNQ==":
+    blobstore_id: 97cc6389-7c8f-4f61-9108-3e7b29bf287d
+    version: 3
+    sha1: !binary |-
+      MjljODRjNTg2YWYzNDM5ODE4YjJkZjU0NzI2NDU2MTIwYjRlNzM4Yw==

--- a/bosh_release/.final_builds/packages/syslog_aggregator/index.yml
+++ b/bosh_release/.final_builds/packages/syslog_aggregator/index.yml
@@ -17,3 +17,8 @@ builds:
     version: 4
     sha1: !binary |-
       MmNlMzVkYzU4YTU3Zjc3NWJjNjhhODBjMDM2ZmY2Mzg5YjNiZWM1MQ==
+  !binary "ZTJhNzliMWQ3MzExNWE0M2E1OTJiMWZjYTQyZjUyZWVkNDQyMTkwNQ==":
+    blobstore_id: 55673e9c-7a62-405b-b340-cf3985d73a9d
+    version: 5
+    sha1: !binary |-
+      NmVmOWNiNjYyYWI2MjM0NzJkMjI2MDZjMDdjYmNjYjk4YzkwM2NmYQ==

--- a/bosh_release/.final_builds/packages/uaa/index.yml
+++ b/bosh_release/.final_builds/packages/uaa/index.yml
@@ -107,3 +107,13 @@ builds:
     version: 26
     sha1: !binary |-
       Yjc4MWFlZTEzMzA2Y2ZiNjQ2NTNmODUyNjA2MDFjYjI0Mzk2Zjg0NQ==
+  !binary "YzVlMTVmNjRkNDg3OTAzM2IxZjZkYjM2YTczMTAzMmEwNzFlYmVjNA==":
+    blobstore_id: 0b74b75d-ec35-4cc6-b0b6-7b738cf8bd2e
+    version: 27
+    sha1: !binary |-
+      OGJjZjRlZjQ3N2M0MTdiOGMzYzI4ZmUzMTMxMzdiMmMwMGRjYjVkZQ==
+  !binary "Mzg3MDcxZTVkNjM5YTJmMDExMDNlZTQzYzhiYTk0YTk5ZmM5NmQyMg==":
+    blobstore_id: f855402b-00cc-485b-8c8e-c0d6c7bd5b2b
+    version: 28
+    sha1: !binary |-
+      NTViNzg3ZTRlNjM1ZjMyYWVkYmE0ZWI0Y2MzZDFhOGUwOTU4ZGYzYw==

--- a/bosh_release/.final_builds/packages/warden/index.yml
+++ b/bosh_release/.final_builds/packages/warden/index.yml
@@ -110,3 +110,13 @@ builds:
     version: 27
     sha1: !binary |-
       ODUyODRjYWU3NmY2Yzg1MTdhY2ZiYjljMjJlZjAyNzRmZDFkMWU3MQ==
+  !binary "OGY5MDVkZjYwNTkyYmVhMzNlMWFhNDBjODM2MDIwZjAxMmI1MjEzNg==":
+    blobstore_id: 3dc7b299-4177-46b2-99a3-8b751896874a
+    version: 28
+    sha1: !binary |-
+      NTFjNjA0ZTgyYTU0YTI2ZGJhMTBkMTRmYzY5Y2NhM2RjMGI4NjQzOQ==
+  !binary "NDcwMmFiYWNiOTg2ZDI3MmM2ZTU4ZmQ0NGIxNTViNmJiZjQ0MWE3Mg==":
+    blobstore_id: 15adc4c7-8326-46db-b6f0-b409a8934a69
+    version: 29
+    sha1: !binary |-
+      NjZjNTU5OWMyODFkMzQ0ZmExOWNmZjA5NDViODQwMjE0YWE3ZmM5YQ==

--- a/bosh_release/config/final.yml
+++ b/bosh_release/config/final.yml
@@ -1,5 +1,5 @@
 ---
-final_name: cf-release
+final_name: cf
 min_cli_version: 1.5.0
 blobstore:
   provider: s3

--- a/bosh_release/releases/cf-136.yml
+++ b/bosh_release/releases/cf-136.yml
@@ -1,0 +1,336 @@
+---
+packages:
+- name: rootfs_lucid64
+  version: 1
+  sha1: !binary |-
+    YjAxMjgyNjk2NmFhOGVjOTNlM2FmODE1ZTI3NzEyZDkzZjVlODk1Mg==
+  fingerprint: !binary |-
+    NzViODBlMmQwNDg2M2E1N2EyM2UxYWRiMTc3ZGI5ODIyM2JjZWRlNA==
+  dependencies: []
+- name: saml_login
+  version: 3
+  sha1: !binary |-
+    MjljODRjNTg2YWYzNDM5ODE4YjJkZjU0NzI2NDU2MTIwYjRlNzM4Yw==
+  fingerprint: !binary |-
+    ZWMzMTEyZTljZTEyOGJkYzIxMzFhYmJmM2IxYjg5YTIzNGNhYWFkNQ==
+  dependencies:
+  - ruby
+  - git
+- name: git
+  version: 1
+  sha1: !binary |-
+    ZjgwYWVjYzVjMTcxYTgwNWNlNDBiZjQwYmNmNWEwMWYwOTc3YjIxOQ==
+  fingerprint: !binary |-
+    OGFkYjdlMTRkZmJmMzViNTRmZmMwOTQyMDZmNjZlYTE0MTE3YmNiMA==
+  dependencies: []
+- name: ruby
+  version: 9
+  sha1: !binary |-
+    NGNmNmMxYWFmOTdjZTU3MjkyYzE2ZDBiOGVkNTBhZTc4MDBkYWY2Yg==
+  fingerprint: !binary |-
+    MGNlZTMwYTYwNmQ4NjI3NzdmYWY4NDZhYzQ4NDhjZTE4NjY1YzA5OQ==
+  dependencies:
+  - libyaml
+- name: gorouter
+  version: 8
+  sha1: !binary |-
+    NmJjODgwZWMzOTQwOTcyZDNjYjViNmZjMmViNTNmNzAyZTlmOTVlMg==
+  fingerprint: !binary |-
+    NjY2MTJlYTE3MTA2MzIyNWRiN2Q4YTQzNTI4OTYwZjFhYzBjNTM1Ng==
+  dependencies:
+  - golang
+- name: syslog_aggregator
+  version: 5
+  sha1: !binary |-
+    NmVmOWNiNjYyYWI2MjM0NzJkMjI2MDZjMDdjYmNjYjk4YzkwM2NmYQ==
+  fingerprint: !binary |-
+    ZTJhNzliMWQ3MzExNWE0M2E1OTJiMWZjYTQyZjUyZWVkNDQyMTkwNQ==
+  dependencies:
+  - ruby
+- name: dea_jvm
+  version: 4
+  sha1: !binary |-
+    MzA5ZDQxYTM3MWU5NmQ0Y2NmZThjYzZiMmJiM2JjY2MzMzJkYjdkMQ==
+  fingerprint: !binary |-
+    MzgzM2QyOWM3YzU0ZjI0MjhmMjY2Y2VkY2U2NDA4NWNlMGNhYTQ4NA==
+  dependencies: []
+- name: postgres
+  version: 4
+  sha1: !binary |-
+    MzBjMWFiYmY3MjQ2OGZjYjUxMTJhMDFkNGY4NGMyMTI0MzY3OGE4NQ==
+  fingerprint: !binary |-
+    YTJiNzcxM2I0ZGY2YzVhYjFhYThhNTMyMWQ4MGYxMTAwZWFlYTc4NA==
+  dependencies: []
+- name: cloud_controller_ng
+  version: 17
+  sha1: !binary |-
+    NmIxMDVhOThhOTcwNmMxZjk0MWNmNzZlMTNkMzAyYzdmMGI1NzQyZA==
+  fingerprint: !binary |-
+    ZGU1MjVkY2E4OGZlN2M3YjYxODZjZTI3MTQ5YzJlYTgyYTFmZjBlYQ==
+  dependencies:
+  - libpq
+  - mysqlclient
+  - sqlite
+  - ruby
+- name: uaa
+  version: 28
+  sha1: !binary |-
+    NTViNzg3ZTRlNjM1ZjMyYWVkYmE0ZWI0Y2MzZDFhOGUwOTU4ZGYzYw==
+  fingerprint: !binary |-
+    Mzg3MDcxZTVkNjM5YTJmMDExMDNlZTQzYzhiYTk0YTk5ZmM5NmQyMg==
+  dependencies:
+  - ruby
+- name: dea_next
+  version: 20
+  sha1: !binary |-
+    OWJmZGYxZTEzYTEwNTVkY2QwOGQwZmNjMGY0ZGQ1ZDZlYzI2ZDE0MQ==
+  fingerprint: !binary |-
+    MzBkYjY1MGNiZGNjNTRlYjk1ZmYzZDgxYWQxMTIzZGMyY2JlZTY3Mw==
+  dependencies:
+  - ruby
+  - buildpack_cache
+  - warden
+  - golang
+  - insight_agent
+  - libyaml
+- name: debian_nfs_server
+  version: 3
+  sha1: !binary |-
+    OThmYTRkY2I5MWFiYThlMDQ0OTI3MTNkODFhZjhlNjg4OTRjMDgxMg==
+  fingerprint: !binary |-
+    YzFkYzg2MGVkNmFiMmJlZTY4MTcyYmU5OTZmNjRmOTU4N2U5YWMwZA==
+  dependencies: []
+- name: buildpack_cache
+  version: 2
+  sha1: !binary |-
+    NmJlZjhkYTQzOGJhODA3YzQ2OTQ0ZWVkYzk3NzhhMGY1MTVkNTFlZA==
+  fingerprint: !binary |-
+    ZjBkYTVjM2QzM2Q4ZTE4ZjY5MjMyNjQ1MTQ3MmRmMjM4YTY3YTBkYw==
+  dependencies: []
+- name: sqlite
+  version: 3
+  sha1: !binary |-
+    OGE3ZjBkMTU3MmVkYjQ2YTFmYjU2OTBjMjdiNWZjNzIwMDc2Njc1Yw==
+  fingerprint: !binary |-
+    ZTNlOWI2MWY4Y2RjMjYxMDQ4MGMyYWE4NDFlODlkYzBiYjFkYzljOQ==
+  dependencies: []
+- name: loggregator
+  version: 1
+  sha1: !binary |-
+    YTM0ZWI0MGIyMjQ2NGExNjAyNTM0ZmIzNDI2N2Q2N2VkMDdlMzNiOA==
+  fingerprint: !binary |-
+    ZmI1YWJkZDU3NTA3YTIyN2RhN2Q2ZWYwOGEzNWVmZTkwZWViZmI4Yg==
+  dependencies: []
+- name: mysqlclient
+  version: 3
+  sha1: !binary |-
+    MDQ0YmEwNTRjNTIzNDdiYTMxNTNlYWNkMWM4NjNlMjc5MmEyN2UxNA==
+  fingerprint: !binary |-
+    ODEwMDlmMmFkNzBjYzE4YjdlOGI4YWY2YTE4OTBhZWM1ZmNjOTM2OQ==
+  dependencies: []
+- name: libyaml
+  version: 1
+  sha1: !binary |-
+    NjgxZDc5MTU0MjhmMjExZGRjN2RjNTZlZWRkYjY1MWE1NTNlMmZmMA==
+  fingerprint: !binary |-
+    ODcwNmY2MTM1NTZmMWFlYmVlNzI5NDk1NjYyNmQ3MDYxZmIyZmE1ZA==
+  dependencies: []
+- name: golang
+  version: 2
+  sha1: !binary |-
+    YzAzMzBiMjU0MmEzOWEwNDIyYTExNmU5ZjVhZjRhZmY3Y2I3ZGQ4MQ==
+  fingerprint: !binary |-
+    N2Q2NmE5MWU0MGI3ODA2MGUyOTEyYWRjZmFmN2Q1MDVkZmNlYzRlYQ==
+  dependencies: []
+- name: collector
+  version: 11
+  sha1: !binary |-
+    NGRkZmIwMTk3YWRmYWE4ZmY0ZDIxNjZjNmM1ODVjMGVkNWIxNGQzMQ==
+  fingerprint: !binary |-
+    YTg4MTUyZWZlMmFlNzFhODUxNzI0MDk5NTIzZjI0OTYxZjQzODBmOA==
+  dependencies:
+  - ruby
+- name: nats
+  version: 8
+  sha1: !binary |-
+    YWRkZmQ1YTBlNDExZTI0NWJlZmQ2MzVkNGFhM2ZhZmFiMWJjODZkNQ==
+  fingerprint: !binary |-
+    MGUzYmFlM2NmNTc0MmU4ZTc1NDI5NWM5ZDA4ODgxMWI0YWUxZDNhMw==
+  dependencies:
+  - ruby
+- name: cfop
+  version: 1
+  sha1: !binary |-
+    ZjEzY2QzNTdkOGUzNzVkNjM4YmViOGM0MGY5YzEwMWUyMjVkYmJhYQ==
+  fingerprint: !binary |-
+    ZTk1OWE1YmJmMDhkYzRlZjU3ZDM3NWQ1MmM0Y2E1MDU0MDcwZmFmNA==
+  dependencies: []
+- name: warden
+  version: 29
+  sha1: !binary |-
+    NjZjNTU5OWMyODFkMzQ0ZmExOWNmZjA5NDViODQwMjE0YWE3ZmM5YQ==
+  fingerprint: !binary |-
+    NDcwMmFiYWNiOTg2ZDI3MmM2ZTU4ZmQ0NGIxNTViNmJiZjQ0MWE3Mg==
+  dependencies:
+  - ruby
+- name: nginx
+  version: 9
+  sha1: !binary |-
+    ZDgzY2ZjMmQzOGYzZWI3YTI3YWNlYjRiNjI0ODJmZGU2NDQ1NjExMA==
+  fingerprint: !binary |-
+    NzQwYTA1NGYyOWJlYTNhYzM4MmEzMmFiNjcxNTg1MWMxMzk4ZmM0ZA==
+  dependencies: []
+- name: insight_agent
+  version: 2
+  sha1: !binary |-
+    ZmYzYjA2YmQ5OTQ1NGFlZjhlYzFkNzMyMzQ1NWRhZTQxN2JkMWE2OQ==
+  fingerprint: !binary |-
+    YmMxOTM2MDkxMDYxYWQ5YWJmOWVhMjk3NTVhN2M2Y2FmMzQwNGQzOA==
+  dependencies: []
+- name: dea_logging_agent
+  version: 1
+  sha1: !binary |-
+    YWZhYzE5ZTlkYTBiYjA3ZTc2Mzc4YWM2YjViYjIxY2ZkYzZjMjlkYg==
+  fingerprint: !binary |-
+    NmNhZWJiYzliNzRkY2RjMjIzNDM2MGFlYjM0NzNiMjlkNGM0NjI1OA==
+  dependencies: []
+- name: login
+  version: 17
+  sha1: !binary |-
+    OTBmM2RkMGY0NjVkZjM5MGIwMGM0MmZhZWI5MjliMzFjYzdmZjZmOQ==
+  fingerprint: !binary |-
+    MzBkY2ZlOWM3ZTI0MzdiZjYzYzNjNDJhOTUxOTEwYzU3MjQxYTgxYg==
+  dependencies:
+  - ruby
+- name: health_manager_next
+  version: 20
+  sha1: !binary |-
+    YzQ2ZGJlNjM0NmRmY2I5ZmViY2Y5MDYyYTM3ZThjZDMyYzJjYTE0Mg==
+  fingerprint: !binary |-
+    NTY0OWU3MTBmNGQ4YzRjY2RiNGZlYWNhMjc0OTZmZWNjNjJlMDY4OA==
+  dependencies:
+  - ruby
+- name: common
+  version: 5
+  sha1: !binary |-
+    MDExNjU5YWM3MTNlZDNjOGUzZDc0MWQxYmFkNjI3ZTRkOWQ2OGNjMQ==
+  fingerprint: !binary |-
+    NDdlYWMzYzQxNmY4N2ViMGE2NDhiM2RmZTQ1NjMyYzY1NGQ2ZTY3Zg==
+  dependencies: []
+- name: dashboard
+  version: 15
+  sha1: !binary |-
+    ZWU0YzA3MzA2ZTAxZWI3OGU2ZDY4YTRkOTZiNzVjNjg4NDdiMTZmNQ==
+  fingerprint: !binary |-
+    YTgwNmU2YWI5NmRiMjZlMzNlNjdjYTc4MTE1ZTQzOGIyMzA3YzA1Yw==
+  dependencies:
+  - ruby
+  - dea_jvm
+- name: libpq
+  version: 5
+  sha1: !binary |-
+    MTdmMDQyZGMzYmFmZmE5ZjVjNTQ3ZDU4MzVjZGE1ZDcyNGFiNTQ5MA==
+  fingerprint: !binary |-
+    NTYzMjRlMGNkYTY2ZWYwZjQxMWM1MDg0ZDgzZmYxMGVkZDNmZWI2Nw==
+  dependencies: []
+jobs:
+- name: saml_login
+  version: 3
+  fingerprint: !binary |-
+    MGQ4MTE4YjQzOWExNzAzYjQ0ZTZjMDJkODE0NTk3ZTFlZTg3MTU0OA==
+  sha1: !binary |-
+    YTU5Y2JmMmJlNmYwYzllNzM1OWVlNjYwMzUwZTE1NDlmZDllZGZiNA==
+- name: gorouter
+  version: 2
+  fingerprint: !binary |-
+    ZTI2MDc2ZDVhZmUzMGZjMjYzZmZlZDZmYWMyNTZjOTgwYTlhMjBkNg==
+  sha1: !binary |-
+    YzU5MDkzYjM3MmViZmZiOTc4ZWQ3ZjY1NDlmNjM1MDAwZTlhY2Y3OQ==
+- name: syslog_aggregator
+  version: 12
+  fingerprint: !binary |-
+    ODRmNzBlNTA2YzAxYTVmMTcxZjM5MmQwMTQ4MWFhMzE0MTUxNDA3OA==
+  sha1: !binary |-
+    MTQxYzE4ZGEzNDU2OWZmYmEzMWMxMWVjZjQ5OTQ2ZjJkM2E2ZTY1Ng==
+- name: postgres
+  version: 4
+  fingerprint: !binary |-
+    NTE3YTI5OGJiYWE1MDg5ODViMjlkMTZkNzFlZDhiYzA2MzhiMTYyMw==
+  sha1: !binary |-
+    YWE3NDA0YzAxY2RkMGExYjI4M2FkNDdlYjVkMzAxNDE2YTc5MzM0ZA==
+- name: cloud_controller_ng
+  version: 10
+  fingerprint: !binary |-
+    YTYzNzUwNTI5YmYxOWY4YzBiMGY2OWJmN2Q4ZjY0OGFhZmVlYzI4Yw==
+  sha1: !binary |-
+    NzkzODIzZGVlNDJlM2RkOThjMDk1NDQ2NGIxYzZlNDg1YTYzOGUxZg==
+- name: uaa
+  version: 29
+  fingerprint: !binary |-
+    ODI2YjYzMDE5ZmVhOWFlYWZjNGFkNTNjMmNiZmZiMTY2ZmY4OTkwZQ==
+  sha1: !binary |-
+    NTMzOTRlNDgxZmFiODk5N2QzYjY2NzM4MTA1MDUyMzIzYmMxYjZlMA==
+- name: ccdb_postgres
+  version: 7
+  fingerprint: !binary |-
+    ZmYyZmZkOTE4ZTJmYTkwYjU1ZTI1NmFhOWE3NWY2YjJjODUzMWExZQ==
+  sha1: !binary |-
+    MTRmMDAwOGVlNTc4MGZhOTRmZjE5OTc3NjVmN2FlYjFkM2IwNjcxNw==
+- name: dea_next
+  version: 14
+  fingerprint: !binary |-
+    Yjg3ODUyYTdkYzQ5NDNmYmRlODc5NmQ0MmM2MjQ4M2QxNmIzOWM3Yg==
+  sha1: !binary |-
+    YjRkMjI5ZDQ5NTRjNGY5N2RkYTJlOWYxMWVhZjU0ODgyNDMxNjMyOQ==
+- name: debian_nfs_server
+  version: 7
+  fingerprint: !binary |-
+    MjM0ZmFiYzFhMmM1ZGZiZmQ3YzkzMjg4MmQ5NDdmZWQzMzFiODI5NQ==
+  sha1: !binary |-
+    YjIyOGVjYjk2ZWM1NTUxYWI3MjM5ZWE2ZmRmYTM1MjkzMWRmZTQ1NA==
+- name: loggregator
+  version: 1
+  fingerprint: !binary |-
+    Mzc4OTEyNzljOGE0ZWM4NDNiNWZiMmEyMWIxNDZiMGE4NWNiNmZlZg==
+  sha1: !binary |-
+    ZGE5YTdlMGFkZTU2YTFmNWQ5ZTA4ZTE1ZTJlZWMxOWM5ODgwNDljOQ==
+- name: collector
+  version: 7
+  fingerprint: !binary |-
+    ZDM4OGZhZmJiZjIzMDczMjc3NWYzMTQ1ZWZlNTg2ZDM0YWNkMTA3NQ==
+  sha1: !binary |-
+    NmJiZmI0ODBlNjc0NDM5ZTIxMDUyNzhlYTY0YjVjYzUyOGExNzVkYQ==
+- name: nats
+  version: 11
+  fingerprint: !binary |-
+    YWZlZGRmNWM5OWYyYzc1NmJjZTY5NDY5NmY5YTA3NmRkMTM4MTgxZg==
+  sha1: !binary |-
+    YWE0N2YzODQzNzU1N2RkMTk2ODcyNzJmODA4NWI2YjMzNzZjNDA3Mg==
+- name: dea_logging_agent
+  version: 1
+  fingerprint: !binary |-
+    YzU3MTU4M2E5YTVhNDg2MjQ0YzI2MDA5NDEyZDlkYjBlNjM2YjdmOA==
+  sha1: !binary |-
+    ZGI5MzJmOWFhZTNlOTg0NjhhODA0ZjUwMDc1NTg0MzBmYmZmYjk5Mg==
+- name: login
+  version: 15
+  fingerprint: !binary |-
+    ZTZhN2UwN2JlZWM0OGI4NTQ2OTI0ZDVmNDNmMGFlYzY2Y2U2YTJlYw==
+  sha1: !binary |-
+    MjhkOTAyZjVlYjVlNGE3OTAwZjExZDQxMTJmZjZkZDU0Mjk2NmU0OA==
+- name: health_manager_next
+  version: 9
+  fingerprint: !binary |-
+    NWM2OGU1YzEwOTk5NGYwMWZhYmVkYmFjMjA4NTBkOTU3NzEzYzBmZQ==
+  sha1: !binary |-
+    YzBhZGJmZmZlYWM2ZGQ2NmY0ZTA1NDRhMThjNjYwZDBjNDEyMTMxNQ==
+- name: dashboard
+  version: 10
+  fingerprint: !binary |-
+    YjVhNzdkMTczODFiNWFmMjkxYzk5N2MxMWU5NmEzYTY1NjcwZmVlYg==
+  sha1: !binary |-
+    Njg1OTc4NjI0MGQ1NWIwZmIwMzhmMTNkOTFiZjQwZDY5NTA3MjZlNw==
+commit_hash: db981534
+uncommitted_changes: true
+name: cf
+version: 136

--- a/bosh_release/releases/cf-release-135.yml
+++ b/bosh_release/releases/cf-release-135.yml
@@ -1,0 +1,310 @@
+---
+packages:
+- name: rootfs_lucid64
+  version: 1
+  sha1: !binary |-
+    YjAxMjgyNjk2NmFhOGVjOTNlM2FmODE1ZTI3NzEyZDkzZjVlODk1Mg==
+  fingerprint: !binary |-
+    NzViODBlMmQwNDg2M2E1N2EyM2UxYWRiMTc3ZGI5ODIyM2JjZWRlNA==
+  dependencies: []
+- name: saml_login
+  version: 2
+  sha1: !binary |-
+    MTMyNTlkOTdhZmIxNmFlZjBhOGNmMDY1Y2NlMGFmMDAxOWU5YzU5YQ==
+  fingerprint: !binary |-
+    NjU2MzA2MjY3YjYzNTA0MzJjZWYwNDFkZjk3ZjU4N2MzODY2YmRmYg==
+  dependencies:
+  - ruby
+  - git
+- name: git
+  version: 1
+  sha1: !binary |-
+    ZjgwYWVjYzVjMTcxYTgwNWNlNDBiZjQwYmNmNWEwMWYwOTc3YjIxOQ==
+  fingerprint: !binary |-
+    OGFkYjdlMTRkZmJmMzViNTRmZmMwOTQyMDZmNjZlYTE0MTE3YmNiMA==
+  dependencies: []
+- name: ruby
+  version: 9
+  sha1: !binary |-
+    NGNmNmMxYWFmOTdjZTU3MjkyYzE2ZDBiOGVkNTBhZTc4MDBkYWY2Yg==
+  fingerprint: !binary |-
+    MGNlZTMwYTYwNmQ4NjI3NzdmYWY4NDZhYzQ4NDhjZTE4NjY1YzA5OQ==
+  dependencies:
+  - libyaml
+- name: gorouter
+  version: 7
+  sha1: !binary |-
+    MmMwMDQ0YzU1OTExY2RlZmJmNDA2ZTk5MjFiNDYyZTQ4NmJjNDUyNg==
+  fingerprint: !binary |-
+    Mzk5MDYxODg3MjY5YWYxM2Q2MmEwNzUyYzIxZjQ5NGMxMTRjMDY2ZA==
+  dependencies:
+  - golang
+- name: syslog_aggregator
+  version: 5
+  sha1: !binary |-
+    NmVmOWNiNjYyYWI2MjM0NzJkMjI2MDZjMDdjYmNjYjk4YzkwM2NmYQ==
+  fingerprint: !binary |-
+    ZTJhNzliMWQ3MzExNWE0M2E1OTJiMWZjYTQyZjUyZWVkNDQyMTkwNQ==
+  dependencies:
+  - ruby
+- name: dea_jvm
+  version: 4
+  sha1: !binary |-
+    MzA5ZDQxYTM3MWU5NmQ0Y2NmZThjYzZiMmJiM2JjY2MzMzJkYjdkMQ==
+  fingerprint: !binary |-
+    MzgzM2QyOWM3YzU0ZjI0MjhmMjY2Y2VkY2U2NDA4NWNlMGNhYTQ4NA==
+  dependencies: []
+- name: postgres
+  version: 4
+  sha1: !binary |-
+    MzBjMWFiYmY3MjQ2OGZjYjUxMTJhMDFkNGY4NGMyMTI0MzY3OGE4NQ==
+  fingerprint: !binary |-
+    YTJiNzcxM2I0ZGY2YzVhYjFhYThhNTMyMWQ4MGYxMTAwZWFlYTc4NA==
+  dependencies: []
+- name: cloud_controller_ng
+  version: 16
+  sha1: !binary |-
+    ZWEzZWJkMmRjZjA0MjBiNzYxYmZmNGExZWMxNjYyNTBhMDBhYzhkNQ==
+  fingerprint: !binary |-
+    MGYxYWFkYzZlNDFhNDZmNzlkNTBkNjE1MmZmMjczNzg5ZjcyM2I2MA==
+  dependencies:
+  - libpq
+  - mysqlclient
+  - sqlite
+  - ruby
+- name: uaa
+  version: 27
+  sha1: !binary |-
+    OGJjZjRlZjQ3N2M0MTdiOGMzYzI4ZmUzMTMxMzdiMmMwMGRjYjVkZQ==
+  fingerprint: !binary |-
+    YzVlMTVmNjRkNDg3OTAzM2IxZjZkYjM2YTczMTAzMmEwNzFlYmVjNA==
+  dependencies:
+  - ruby
+- name: dea_next
+  version: 19
+  sha1: !binary |-
+    MjQ5MzcwOTA1YmZlMDcxNzZkYzA0NDkzNTVkODkwODBiMWVkY2JmNQ==
+  fingerprint: !binary |-
+    MzYxZjRkYzY0ZmQzY2ZjMzcyMjhiYmQ3MTU0NjllOWNjZDU5ZWIxNA==
+  dependencies:
+  - ruby
+  - buildpack_cache
+  - warden
+  - golang
+  - insight_agent
+  - libyaml
+- name: debian_nfs_server
+  version: 3
+  sha1: !binary |-
+    OThmYTRkY2I5MWFiYThlMDQ0OTI3MTNkODFhZjhlNjg4OTRjMDgxMg==
+  fingerprint: !binary |-
+    YzFkYzg2MGVkNmFiMmJlZTY4MTcyYmU5OTZmNjRmOTU4N2U5YWMwZA==
+  dependencies: []
+- name: buildpack_cache
+  version: 2
+  sha1: !binary |-
+    NmJlZjhkYTQzOGJhODA3YzQ2OTQ0ZWVkYzk3NzhhMGY1MTVkNTFlZA==
+  fingerprint: !binary |-
+    ZjBkYTVjM2QzM2Q4ZTE4ZjY5MjMyNjQ1MTQ3MmRmMjM4YTY3YTBkYw==
+  dependencies: []
+- name: sqlite
+  version: 3
+  sha1: !binary |-
+    OGE3ZjBkMTU3MmVkYjQ2YTFmYjU2OTBjMjdiNWZjNzIwMDc2Njc1Yw==
+  fingerprint: !binary |-
+    ZTNlOWI2MWY4Y2RjMjYxMDQ4MGMyYWE4NDFlODlkYzBiYjFkYzljOQ==
+  dependencies: []
+- name: mysqlclient
+  version: 3
+  sha1: !binary |-
+    MDQ0YmEwNTRjNTIzNDdiYTMxNTNlYWNkMWM4NjNlMjc5MmEyN2UxNA==
+  fingerprint: !binary |-
+    ODEwMDlmMmFkNzBjYzE4YjdlOGI4YWY2YTE4OTBhZWM1ZmNjOTM2OQ==
+  dependencies: []
+- name: libyaml
+  version: 1
+  sha1: !binary |-
+    NjgxZDc5MTU0MjhmMjExZGRjN2RjNTZlZWRkYjY1MWE1NTNlMmZmMA==
+  fingerprint: !binary |-
+    ODcwNmY2MTM1NTZmMWFlYmVlNzI5NDk1NjYyNmQ3MDYxZmIyZmE1ZA==
+  dependencies: []
+- name: golang
+  version: 2
+  sha1: !binary |-
+    YzAzMzBiMjU0MmEzOWEwNDIyYTExNmU5ZjVhZjRhZmY3Y2I3ZGQ4MQ==
+  fingerprint: !binary |-
+    N2Q2NmE5MWU0MGI3ODA2MGUyOTEyYWRjZmFmN2Q1MDVkZmNlYzRlYQ==
+  dependencies: []
+- name: collector
+  version: 10
+  sha1: !binary |-
+    N2FkOGQ5YzI2MmEwYzZlMTkxN2Q2ZTEzMzM5NzcyODZiZjhmOGNmOA==
+  fingerprint: !binary |-
+    MWQyMDAxNDc4NzUxMDQzNzNiZDQxMGJlNzRmYTExNDE5NDQzYjFkNg==
+  dependencies:
+  - ruby
+- name: nats
+  version: 8
+  sha1: !binary |-
+    YWRkZmQ1YTBlNDExZTI0NWJlZmQ2MzVkNGFhM2ZhZmFiMWJjODZkNQ==
+  fingerprint: !binary |-
+    MGUzYmFlM2NmNTc0MmU4ZTc1NDI5NWM5ZDA4ODgxMWI0YWUxZDNhMw==
+  dependencies:
+  - ruby
+- name: cfop
+  version: 1
+  sha1: !binary |-
+    ZjEzY2QzNTdkOGUzNzVkNjM4YmViOGM0MGY5YzEwMWUyMjVkYmJhYQ==
+  fingerprint: !binary |-
+    ZTk1OWE1YmJmMDhkYzRlZjU3ZDM3NWQ1MmM0Y2E1MDU0MDcwZmFmNA==
+  dependencies: []
+- name: warden
+  version: 28
+  sha1: !binary |-
+    NTFjNjA0ZTgyYTU0YTI2ZGJhMTBkMTRmYzY5Y2NhM2RjMGI4NjQzOQ==
+  fingerprint: !binary |-
+    OGY5MDVkZjYwNTkyYmVhMzNlMWFhNDBjODM2MDIwZjAxMmI1MjEzNg==
+  dependencies:
+  - ruby
+- name: nginx
+  version: 9
+  sha1: !binary |-
+    ZDgzY2ZjMmQzOGYzZWI3YTI3YWNlYjRiNjI0ODJmZGU2NDQ1NjExMA==
+  fingerprint: !binary |-
+    NzQwYTA1NGYyOWJlYTNhYzM4MmEzMmFiNjcxNTg1MWMxMzk4ZmM0ZA==
+  dependencies: []
+- name: insight_agent
+  version: 2
+  sha1: !binary |-
+    ZmYzYjA2YmQ5OTQ1NGFlZjhlYzFkNzMyMzQ1NWRhZTQxN2JkMWE2OQ==
+  fingerprint: !binary |-
+    YmMxOTM2MDkxMDYxYWQ5YWJmOWVhMjk3NTVhN2M2Y2FmMzQwNGQzOA==
+  dependencies: []
+- name: login
+  version: 16
+  sha1: !binary |-
+    OTJiMTMzMjk4ZDk3ZTIwMzQ2ZjMyOGEwODZiZjc3NTkyODcyMDY0Yw==
+  fingerprint: !binary |-
+    YTA5MzQ0ZTAzNGQ4Y2NiMDg1ODcxMWI2YWI1ZDExNWI1MzcwMTg3ZQ==
+  dependencies:
+  - ruby
+- name: health_manager_next
+  version: 19
+  sha1: !binary |-
+    M2ZhZDMxOGQzYTM3YWUyM2IyYzY1NTg1YTVmZTJlYWEzZTA2YjIyZA==
+  fingerprint: !binary |-
+    NzZmNDI2NGE4NGMyMjBlM2NjMWQ0YjQ0NTljNjhlMWM0OTY0MGNmMg==
+  dependencies:
+  - ruby
+- name: common
+  version: 5
+  sha1: !binary |-
+    MDExNjU5YWM3MTNlZDNjOGUzZDc0MWQxYmFkNjI3ZTRkOWQ2OGNjMQ==
+  fingerprint: !binary |-
+    NDdlYWMzYzQxNmY4N2ViMGE2NDhiM2RmZTQ1NjMyYzY1NGQ2ZTY3Zg==
+  dependencies: []
+- name: dashboard
+  version: 14
+  sha1: !binary |-
+    YzY3ODE3ZjE0Y2Y3YmI2YjY3OTdlOTkyMTcwNTUyOTA5ZjYzMzQ2OA==
+  fingerprint: !binary |-
+    MzgwYjZlMTMyNmE0MGIyZDIwMDZiNTYwNDA0NDU1NzYzZTJiNjMwYQ==
+  dependencies:
+  - ruby
+  - dea_jvm
+- name: libpq
+  version: 5
+  sha1: !binary |-
+    MTdmMDQyZGMzYmFmZmE5ZjVjNTQ3ZDU4MzVjZGE1ZDcyNGFiNTQ5MA==
+  fingerprint: !binary |-
+    NTYzMjRlMGNkYTY2ZWYwZjQxMWM1MDg0ZDgzZmYxMGVkZDNmZWI2Nw==
+  dependencies: []
+jobs:
+- name: saml_login
+  version: 2
+  fingerprint: !binary |-
+    MmZiZTZhNzQwNjJhNjkxOWM3OTkxZjQwODRjYTFlMDg2OGI2MGU2NQ==
+  sha1: !binary |-
+    ZjA3N2UyZWQ5NzI1Y2VlMWIyMzJmMjU2MDRkNDE0NDQ3ODllMzA5Zg==
+- name: gorouter
+  version: 2
+  fingerprint: !binary |-
+    ZTI2MDc2ZDVhZmUzMGZjMjYzZmZlZDZmYWMyNTZjOTgwYTlhMjBkNg==
+  sha1: !binary |-
+    YzU5MDkzYjM3MmViZmZiOTc4ZWQ3ZjY1NDlmNjM1MDAwZTlhY2Y3OQ==
+- name: syslog_aggregator
+  version: 12
+  fingerprint: !binary |-
+    ODRmNzBlNTA2YzAxYTVmMTcxZjM5MmQwMTQ4MWFhMzE0MTUxNDA3OA==
+  sha1: !binary |-
+    MTQxYzE4ZGEzNDU2OWZmYmEzMWMxMWVjZjQ5OTQ2ZjJkM2E2ZTY1Ng==
+- name: postgres
+  version: 4
+  fingerprint: !binary |-
+    NTE3YTI5OGJiYWE1MDg5ODViMjlkMTZkNzFlZDhiYzA2MzhiMTYyMw==
+  sha1: !binary |-
+    YWE3NDA0YzAxY2RkMGExYjI4M2FkNDdlYjVkMzAxNDE2YTc5MzM0ZA==
+- name: cloud_controller_ng
+  version: 9
+  fingerprint: !binary |-
+    MTdhM2MyZjc4YWVlNzIxZTI4MjZkMGFjYTFkYzUxNGE3NmY3ZGNlOA==
+  sha1: !binary |-
+    YTg0ZjAyNGU1YjRhMzY1OGM3ZGU3MDAyNWU1MGNkZTUzYzgzYzliMQ==
+- name: uaa
+  version: 29
+  fingerprint: !binary |-
+    ODI2YjYzMDE5ZmVhOWFlYWZjNGFkNTNjMmNiZmZiMTY2ZmY4OTkwZQ==
+  sha1: !binary |-
+    NTMzOTRlNDgxZmFiODk5N2QzYjY2NzM4MTA1MDUyMzIzYmMxYjZlMA==
+- name: ccdb_postgres
+  version: 7
+  fingerprint: !binary |-
+    ZmYyZmZkOTE4ZTJmYTkwYjU1ZTI1NmFhOWE3NWY2YjJjODUzMWExZQ==
+  sha1: !binary |-
+    MTRmMDAwOGVlNTc4MGZhOTRmZjE5OTc3NjVmN2FlYjFkM2IwNjcxNw==
+- name: dea_next
+  version: 14
+  fingerprint: !binary |-
+    Yjg3ODUyYTdkYzQ5NDNmYmRlODc5NmQ0MmM2MjQ4M2QxNmIzOWM3Yg==
+  sha1: !binary |-
+    YjRkMjI5ZDQ5NTRjNGY5N2RkYTJlOWYxMWVhZjU0ODgyNDMxNjMyOQ==
+- name: debian_nfs_server
+  version: 7
+  fingerprint: !binary |-
+    MjM0ZmFiYzFhMmM1ZGZiZmQ3YzkzMjg4MmQ5NDdmZWQzMzFiODI5NQ==
+  sha1: !binary |-
+    YjIyOGVjYjk2ZWM1NTUxYWI3MjM5ZWE2ZmRmYTM1MjkzMWRmZTQ1NA==
+- name: collector
+  version: 7
+  fingerprint: !binary |-
+    ZDM4OGZhZmJiZjIzMDczMjc3NWYzMTQ1ZWZlNTg2ZDM0YWNkMTA3NQ==
+  sha1: !binary |-
+    NmJiZmI0ODBlNjc0NDM5ZTIxMDUyNzhlYTY0YjVjYzUyOGExNzVkYQ==
+- name: nats
+  version: 11
+  fingerprint: !binary |-
+    YWZlZGRmNWM5OWYyYzc1NmJjZTY5NDY5NmY5YTA3NmRkMTM4MTgxZg==
+  sha1: !binary |-
+    YWE0N2YzODQzNzU1N2RkMTk2ODcyNzJmODA4NWI2YjMzNzZjNDA3Mg==
+- name: login
+  version: 14
+  fingerprint: !binary |-
+    NzU3NTg2OTFhODI3NmJmMjhiOTUxODZkNWIxYTE5ZGY2Zjg5NjFhYQ==
+  sha1: !binary |-
+    NjA0Y2ZiOWI0ZWM1YTZiYjViZmNkNzQ0ZWE0NzViNmRiZmQyMTNhNg==
+- name: health_manager_next
+  version: 9
+  fingerprint: !binary |-
+    NWM2OGU1YzEwOTk5NGYwMWZhYmVkYmFjMjA4NTBkOTU3NzEzYzBmZQ==
+  sha1: !binary |-
+    YzBhZGJmZmZlYWM2ZGQ2NmY0ZTA1NDRhMThjNjYwZDBjNDEyMTMxNQ==
+- name: dashboard
+  version: 10
+  fingerprint: !binary |-
+    YjVhNzdkMTczODFiNWFmMjkxYzk5N2MxMWU5NmEzYTY1NjcwZmVlYg==
+  sha1: !binary |-
+    Njg1OTc4NjI0MGQ1NWIwZmIwMzhmMTNkOTFiZjQwZDY5NTA3MjZlNw==
+commit_hash: b52d98d7
+uncommitted_changes: true
+name: cf-release
+version: 135

--- a/bosh_release/releases/index.yml
+++ b/bosh_release/releases/index.yml
@@ -268,3 +268,7 @@ builds:
     version: 133
   !binary "NzRlZDM1YjQ4YjlhOTQwZTg0MDU0YzQ5MWZlNmQ0Yzg0NGM1NTc1Zg==":
     version: 134
+  !binary "ZTFhNGIwYmMxYTA0ODFkMjk5MzZjZGY2ZGY1MzZkNWZlNGRiZTY1ZQ==":
+    version: 135
+  !binary "YTJiOWYzYjA1YWMwYzk0ZTBkN2RhY2E3NDk5YzBjZDQyM2M5MWJhMw==":
+    version: 136

--- a/lib/bosh/cloudfoundry/release_version.rb
+++ b/lib/bosh/cloudfoundry/release_version.rb
@@ -6,7 +6,6 @@ module Bosh::Cloudfoundry
   # From this class you can navigate to ReleaseVersionCpi for the CPI specific aspect of a release version;
   # and from ReleaseVersionCpi you can navigate to one or more ReleaseVersionCpiSizes (deployment sizes).
   class ReleaseVersion
-    attr_reader :release_name
     attr_reader :version_number
 
     def self.for_version(version_number)
@@ -43,7 +42,13 @@ module Bosh::Cloudfoundry
 
     def initialize(version_number)
       @version_number = version_number
-      @release_name = "cf-release" # TODO determine from release file
+    end
+
+    def release_name
+      @release_name ||= begin
+        release_yml = Dir[File.join(bosh_release_dir, "releases", "*-#{release_version}.yml")].first
+        YAML.load_file(release_yml)["name"]
+      end
     end
 
     # Attributes & their values that can be changed via setters & deployment re-deployed successfully
@@ -62,6 +67,10 @@ module Bosh::Cloudfoundry
 
     def valid_cpi?(cpi)
       available_cpi_names.include?(cpi)
+    end
+
+    def bosh_release_dir
+      File.expand_path("../../../../bosh_release", __FILE__)
     end
 
     def self.base_template_dir

--- a/spec/commands/command_prepare_cf_spec.rb
+++ b/spec/commands/command_prepare_cf_spec.rb
@@ -1,8 +1,6 @@
 require "bosh/cli/commands/01_prepare_bosh_for_cf"
 
 describe Bosh::Cli::Command::PrepareBoshForCloudFoundry do
-  let(:latest_release_version_number) { 134 }
-
   let(:command) { Bosh::Cli::Command::PrepareBoshForCloudFoundry.new }
   let(:director) { instance_double("Bosh::Cli::Director") }
   let(:aws_full_stemcell_url)  { "http://bosh-jenkins-artifacts.s3.amazonaws.com/bosh-stemcell/aws/latest-bosh-stemcell-aws.tgz" }
@@ -25,7 +23,7 @@ describe Bosh::Cli::Command::PrepareBoshForCloudFoundry do
       director.should_receive(:list_releases).and_return([])
       director.should_receive(:list_stemcells).and_return([])
 
-      release_yml = File.expand_path("../../../bosh_release/releases/cf-release-#{latest_release_version_number}.yml", __FILE__)
+      release_yml = File.expand_path("../../../bosh_release/releases/cf-#{latest_cf_release_version}.yml", __FILE__)
       release_cmd = instance_double("Bosh::Cli::Command::Release")
       release_cmd.should_receive(:upload).with(release_yml)
       command.stub(:release_cmd).and_return(release_cmd)
@@ -96,7 +94,7 @@ describe Bosh::Cli::Command::PrepareBoshForCloudFoundry do
       director.should_receive(:list_releases).and_return([])
       director.should_receive(:list_stemcells).and_return([{"name" => "bosh-stemcell", "version" => "something"}])
       
-      release_yml = File.expand_path("../../../bosh_release/releases/cf-release-#{latest_release_version_number}.yml", __FILE__)
+      release_yml = File.expand_path("../../../bosh_release/releases/cf-#{latest_cf_release_version}.yml", __FILE__)
       release_cmd = instance_double("Bosh::Cli::Command::Release")
       release_cmd.should_receive(:upload).with(release_yml)
       command.stub(:release_cmd).and_return(release_cmd)

--- a/spec/release_version_cpi_spec.rb
+++ b/spec/release_version_cpi_spec.rb
@@ -1,6 +1,4 @@
 describe Bosh::Cloudfoundry::ReleaseVersionCpi do
-  let(:latest_release_version_number) { 134 }
-
   subject { Bosh::Cloudfoundry::ReleaseVersionCpi.for_cpi(133, "aws") }
 
   it "has available deployment sizes" do
@@ -14,6 +12,6 @@ describe Bosh::Cloudfoundry::ReleaseVersionCpi do
   it "latest_for_cpi(bosh_cpi)" do
     rvc = Bosh::Cloudfoundry::ReleaseVersionCpi.latest_for_cpi("aws")
     rvc.cpi.should == "aws"
-    rvc.release_version_number.should == latest_release_version_number
+    rvc.release_version_number.should == latest_cf_release_version
   end
 end

--- a/spec/release_version_spec.rb
+++ b/spec/release_version_spec.rb
@@ -1,6 +1,4 @@
 describe Bosh::Cloudfoundry::ReleaseVersion do
-  let(:latest_release_version_number) { 134 }
-
   it "cannot accept versions lower than 132" do
     expect { Bosh::Cloudfoundry::ReleaseVersion.for_version(131) }.to raise_error(RuntimeError)
   end
@@ -10,15 +8,15 @@ describe Bosh::Cloudfoundry::ReleaseVersion do
   end
 
   it "finds an next available version match" do
-    Bosh::Cloudfoundry::ReleaseVersion.for_version(200).version_number.should == latest_release_version_number
+    Bosh::Cloudfoundry::ReleaseVersion.for_version(200).version_number.should == latest_cf_release_version
   end
 
   it "knows available versions" do
-    Bosh::Cloudfoundry::ReleaseVersion.available_versions.should == [132, 133, 134]
+    Bosh::Cloudfoundry::ReleaseVersion.available_versions.should == [132, 133, 134, 136]
   end
 
   it "knows latest version number" do
-    Bosh::Cloudfoundry::ReleaseVersion.latest_version_number.should == latest_release_version_number
+    Bosh::Cloudfoundry::ReleaseVersion.latest_version_number.should == latest_cf_release_version
   end
 
   context "for v132" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,10 @@ Bundler.setup(:default, :test)
 
 $:.unshift(File.expand_path("../../lib", __FILE__))
 
+def latest_cf_release_version
+  136
+end
+
 require "rspec/core"
 require 'rspec/fire'
 

--- a/templates/v136/aws/large/deployment_file.yml.erb
+++ b/templates/v136/aws/large/deployment_file.yml.erb
@@ -1,0 +1,372 @@
+---
+<%-
+# Example source deployment file that can be used:
+# ---
+# name: NAME
+# director_uuid: 4ae3a0f0-70a5-4c0d-95f2-7fafaefe8b9e
+# releases:
+#  - name: cf-release
+#    version: 132
+# networks: {}
+# properties:
+#   cf:
+#     dns: mycloud.com
+#     ip_addresses: ['1.2.3.4']
+#     deployment_size: medium
+#     security_group: cf
+#     persistent_disk: 4096
+#
+# Then target that deployment file:
+#
+#     $ bosh deployment path/to/file/above
+#
+# Then apply this template:
+#
+#     $ bosh diff deployment_file.yml.erb
+#
+name            = find("name")
+dns             = find("properties.cf.dns")
+ip_addresses    = find("properties.cf.ip_addresses")
+security_group  = find("properties.cf.security_group")
+deployment_size = find("properties.cf.deployment_size")
+persistent_disk = find("properties.cf.persistent_disk")
+common_password = find("properties.cf.common_password")
+no_ssl          = true
+protocol        = no_ssl ? "http" : "https"
+-%>
+name: <%= name %>
+director_uuid: <%= find("director_uuid") %>
+
+releases:
+ - name: cf-release
+   version: 136
+
+networks:
+- name: floating
+  type: vip
+  cloud_properties: {}
+- name: default
+  type: dynamic
+  cloud_properties:
+    security_groups:
+    - <%= security_group %>
+
+compilation:
+  workers: 6
+  network: default
+  reuse_compilation_vms: true
+  cloud_properties:
+    instance_type: m1.medium
+
+update:
+  canaries: 1
+  canary_watch_time: 30000-600000
+  update_watch_time: 30000-600000
+  max_in_flight: 4
+  max_errors: 1
+
+resource_pools:
+  - name: small
+    network: default
+    size: 8
+    stemcell:
+      name: bosh-stemcell
+      version: latest
+    cloud_properties:
+      instance_type: m1.small
+
+  - name: large
+    network: default
+    size: 1
+    stemcell:
+      name: bosh-stemcell
+      version: latest
+    cloud_properties:
+      instance_type: m1.large
+
+jobs:
+  - name: syslog_aggregator
+    release: cf-release
+    template: 
+      - syslog_aggregator
+    instances: 1
+    resource_pool: small
+    persistent_disk: 65536
+    networks:
+      - name: default
+        default: [dns, gateway]
+      
+  - name: postgres
+    release: cf-release
+    template: 
+      - postgres
+    instances: 1
+    resource_pool: small
+    persistent_disk: 65536
+    networks:
+      - name: default
+        default: [dns, gateway]
+    properties:
+      db: databases
+
+  - name: nfs_server
+    release: cf-release
+    template:
+      - debian_nfs_server
+    instances: 1
+    resource_pool: small
+    persistent_disk: 65536
+    networks:
+      - name: default
+        default: [dns, gateway]            
+
+  - name: nats
+    release: cf-release
+    template: 
+      - nats
+    instances: 1
+    resource_pool: small
+    networks:
+      - name: default
+        default: [dns, gateway]            
+            
+  - name: uaa
+    release: cf-release
+    template: 
+      - uaa
+    instances: 1
+    resource_pool: small
+    networks:
+      - name: default
+        default: [dns, gateway]           
+
+  - name: cloud_controller
+    release: cf-release
+    template: 
+      - cloud_controller_ng
+    instances: 1
+    resource_pool: small
+    networks:
+      - name: default
+        default: [dns, gateway]
+    properties:
+      ccdb: ccdb
+
+  - name: router
+    release: cf-release
+    template: 
+      - gorouter
+    instances: 1
+    resource_pool: small
+    networks:
+      - name: default
+        default: [dns, gateway]
+      - name: floating
+        static_ips:
+        <%- ip_addresses.each do |ip| -%>
+        - <%= ip %>
+        <%- end -%>
+
+  - name: health_manager
+    release: cf-release
+    template: 
+      - health_manager_next
+    instances: 1
+    resource_pool: small
+    networks:
+      - name: default
+        default: [dns, gateway]
+       
+  - name: dea
+    release: cf-release
+    template: dea_next
+    instances: 1
+    resource_pool: large
+    networks:
+      - name: default
+        default: [dns, gateway]            
+
+properties:
+  cf:
+    name: <%= name %>
+    dns: <%= dns %>
+    ip_addresses: <%= ip_addresses.inspect %>
+    deployment_size: <%= deployment_size %>
+    security_group: <%= security_group %>
+    persistent_disk: <%= persistent_disk %>
+    common_password: <%= common_password %>
+
+  domain: <%= dns %>
+  system_domain: <%= dns %>
+  system_domain_organization: <%= dns %>
+  app_domains:
+    - <%= dns %>
+
+  networks:
+    apps: default
+    management: default
+
+  nats:
+    address: 0.nats.default.<%= name %>.microbosh
+    port: 4222
+    user: nats
+    password: <%= common_password %>
+    authorization_timeout: 5
+
+  router:
+    port: 8081
+    status:
+      port: 8080
+      user: gorouter
+      password: <%= common_password %>
+
+  dea: &dea
+    max_memory: 4096
+    memory_mb: 4096
+    memory_overcommit_factor: 4
+    disk_mb: 16384
+    disk_overcommit_factor: 4
+
+  dea_next: *dea
+
+  syslog_aggregator:
+    address: 0.syslog-aggregator.default.<%= name %>.microbosh
+    port: 54321
+
+  nfs_server:
+    address: 0.nfs-server.default.<%= name %>.microbosh
+    network: "*.<%= name %>.microbosh"
+    idmapd_domain: <%= dns %>
+
+  debian_nfs_server:
+    no_root_squash: true
+
+  databases: &databases
+    db_scheme: postgres
+    address: 0.postgres.default.<%= name %>.microbosh
+    port: 5524
+    roles:
+      - tag: admin
+        name: ccadmin
+        password: <%= common_password %>
+      - tag: admin
+        name: uaaadmin
+        password: <%= common_password %>
+    databases:
+      - tag: cc
+        name: ccdb
+        citext: true
+      - tag: uaa
+        name: uaadb
+        citext: true
+
+  ccdb: &ccdb
+    db_scheme: postgres
+    address: 0.postgres.default.<%= name %>.microbosh
+    port: 5524
+    roles:
+      - tag: admin
+        name: ccadmin
+        password: <%= common_password %>
+    databases:
+      - tag: cc
+        name: ccdb
+        citext: true
+
+  ccdb_ng: *ccdb
+
+  uaadb: 
+    db_scheme: postgresql
+    address: 0.postgres.default.<%= name %>.microbosh
+    port: 5524
+    roles:
+      - tag: admin
+        name: uaaadmin
+        password: <%= common_password %>
+    databases:
+      - tag: uaa
+        name: uaadb
+        citext: true
+
+  cc_api_version: v2
+
+  cc: &cc
+    logging_level: debug
+    external_host: ccng
+    srv_api_uri: <%= protocol %>://api.<%= dns %>
+    cc_partition: default
+    db_encryption_key: <%= common_password %>
+    bootstrap_admin_email: admin@<%= dns %>
+    bulk_api_password: <%= common_password %>
+    uaa_resource_id: cloud_controller
+    staging_upload_user: uploaduser
+    staging_upload_password: <%= common_password %>
+    resource_pool:
+      resource_directory_key: cc-resources
+      # Local provider when using NFS
+      fog_connection:
+        provider: Local
+        local_root: /var/vcap/shared
+    packages:
+      app_package_directory_key: cc-packages
+    droplets:
+      droplet_directory_key: cc-droplets
+    default_quota_definition: runaway
+
+  ccng: *cc
+
+  login:
+    enabled: false
+
+  uaa:
+    url: <%= protocol %>://uaa.<%= dns %>
+    spring_profiles: postgresql
+    no_ssl: <%= no_ssl %>
+    catalina_opts: -Xmx768m -XX:MaxPermSize=256m
+    resource_id: account_manager
+    jwt:
+      signing_key: |
+        -----BEGIN RSA PRIVATE KEY-----
+        MIICXAIBAAKBgQDHFr+KICms+tuT1OXJwhCUmR2dKVy7psa8xzElSyzqx7oJyfJ1
+        JZyOzToj9T5SfTIq396agbHJWVfYphNahvZ/7uMXqHxf+ZH9BL1gk9Y6kCnbM5R6
+        0gfwjyW1/dQPjOzn9N394zd2FJoFHwdq9Qs0wBugspULZVNRxq7veq/fzwIDAQAB
+        AoGBAJ8dRTQFhIllbHx4GLbpTQsWXJ6w4hZvskJKCLM/o8R4n+0W45pQ1xEiYKdA
+        Z/DRcnjltylRImBD8XuLL8iYOQSZXNMb1h3g5/UGbUXLmCgQLOUUlnYt34QOQm+0
+        KvUqfMSFBbKMsYBAoQmNdTHBaz3dZa8ON9hh/f5TT8u0OWNRAkEA5opzsIXv+52J
+        duc1VGyX3SwlxiE2dStW8wZqGiuLH142n6MKnkLU4ctNLiclw6BZePXFZYIK+AkE
+        xQ+k16je5QJBAN0TIKMPWIbbHVr5rkdUqOyezlFFWYOwnMmw/BKa1d3zp54VP/P8
+        +5aQ2d4sMoKEOfdWH7UqMe3FszfYFvSu5KMCQFMYeFaaEEP7Jn8rGzfQ5HQd44ek
+        lQJqmq6CE2BXbY/i34FuvPcKU70HEEygY6Y9d8J3o6zQ0K9SYNu+pcXt4lkCQA3h
+        jJQQe5uEGJTExqed7jllQ0khFJzLMx0K6tj0NeeIzAaGCQz13oo2sCdeGRHO4aDh
+        HH6Qlq/6UOV5wP8+GAcCQFgRCcB+hrje8hfEEefHcFpyKH+5g1Eu1k0mLrxK2zd+
+        4SlotYRHgPCEubokb2S1zfZDWIXW3HmggnGgM949TlY=
+        -----END RSA PRIVATE KEY-----
+      verification_key: |
+        -----BEGIN PUBLIC KEY-----
+        MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDHFr+KICms+tuT1OXJwhCUmR2d
+        KVy7psa8xzElSyzqx7oJyfJ1JZyOzToj9T5SfTIq396agbHJWVfYphNahvZ/7uMX
+        qHxf+ZH9BL1gk9Y6kCnbM5R60gfwjyW1/dQPjOzn9N394zd2FJoFHwdq9Qs0wBug
+        spULZVNRxq7veq/fzwIDAQAB
+        -----END PUBLIC KEY-----
+    cc:
+      client_secret: <%= common_password %>
+    admin:
+      client_secret: <%= common_password %>
+    batch:
+      username: batchuser
+      password: <%= common_password %>
+    client:
+      autoapprove:
+        - cf
+    clients:
+      cf:
+        override: true
+        authorized-grant-types: password,implicit,refresh_token
+        authorities: uaa.none
+        scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write
+        access-token-validity: 7200
+        refresh-token-validity: 1209600
+    scim:
+      users:
+      - admin|<%= common_password %>|scim.write,scim.read,openid,cloud_controller.admin
+      - services|<%= common_password %>|scim.write,scim.read,openid,cloud_controller.admin

--- a/templates/v136/aws/large/spec
+++ b/templates/v136/aws/large/spec
@@ -1,0 +1,6 @@
+---
+resources:
+- small
+- medium
+- large
+- xlarge

--- a/templates/v136/aws/medium/deployment_file.yml.erb
+++ b/templates/v136/aws/medium/deployment_file.yml.erb
@@ -1,0 +1,331 @@
+---
+<%-
+# Example source deployment file that can be used:
+# ---
+# name: NAME
+# director_uuid: 4ae3a0f0-70a5-4c0d-95f2-7fafaefe8b9e
+# releases:
+#  - name: cf-release
+#    version: 132
+# networks: {}
+# properties:
+#   cf:
+#     dns: mycloud.com
+#     ip_addresses: ['1.2.3.4']
+#     deployment_size: medium
+#     security_group: cf
+#     persistent_disk: 4096
+#
+# Then target that deployment file:
+#
+#     $ bosh deployment path/to/file/above
+#
+# Then apply this template:
+#
+#     $ bosh diff deployment_file.yml.erb
+#
+no_ssl          = true
+protocol        = no_ssl ? "http" : "https"
+name            = find("name")
+dns             = find("properties.cf.dns")
+ip_addresses    = find("properties.cf.ip_addresses")
+security_group  = find("properties.cf.security_group")
+deployment_size = find("properties.cf.deployment_size")
+persistent_disk = find("properties.cf.persistent_disk")
+common_password = find("properties.cf.common_password")
+-%>
+name: <%= name %>
+director_uuid: <%= find("director_uuid") %>
+
+releases:
+ - name: cf-release
+   version: 136
+
+networks:
+- name: floating
+  type: vip
+  cloud_properties: {}
+- name: default
+  type: dynamic
+  cloud_properties:
+    security_groups:
+    - <%= security_group %>
+
+update:
+  canaries: 1
+  canary_watch_time: 30000-600000
+  update_watch_time: 30000-600000
+  max_in_flight: 4
+  max_errors: 1
+
+compilation:
+  workers: 6
+  network: default
+  reuse_compilation_vms: true
+  cloud_properties:
+    instance_type: m1.medium
+
+resource_pools:
+  - name: small
+    network: default
+    size: 4
+    stemcell:
+      name: bosh-stemcell
+      version: latest
+    cloud_properties:
+      instance_type: m1.small
+
+  - name: medium
+    network: default
+    size: 0
+    stemcell:
+      name: bosh-stemcell
+      version: latest
+    cloud_properties:
+      instance_type: m1.medium
+
+jobs:
+  - name: data
+    release: cf-release
+    template:
+      - postgres
+      - debian_nfs_server
+    instances: 1
+    resource_pool: small
+    persistent_disk: <%= persistent_disk %>
+    networks:
+    - name: default
+      default:
+      - dns
+      - gateway
+    properties:
+      db: databases
+
+  - name: core
+    release: cf-release
+    template:
+      - nats
+      - health_manager_next
+      - uaa
+    instances: 1
+    resource_pool: small
+    networks:
+    - name: default
+      default:
+      - dns
+      - gateway
+
+  - name: api
+    release: cf-release
+    template:
+      - cloud_controller_ng
+      - gorouter
+    instances: 1
+    resource_pool: small
+    networks:
+    - name: default
+      default:
+      - dns
+      - gateway
+    - name: floating
+      static_ips:
+      <%- ip_addresses.each do |ip| -%>
+      - <%= ip %>
+      <%- end -%>
+    properties:
+      db: databases
+
+  - name: dea
+    release: cf-release
+    template:
+      - dea_next
+    instances: 1
+    resource_pool: small
+    networks:
+      - name: default
+        default: [dns, gateway]
+
+properties:
+  cf:
+    name: <%= name %>
+    dns: <%= dns %>
+    ip_addresses: <%= ip_addresses.inspect %>
+    deployment_size: <%= deployment_size %>
+    security_group: <%= security_group %>
+    persistent_disk: <%= persistent_disk %>
+    common_password: <%= common_password %>
+
+  domain: <%= dns %>
+  system_domain: <%= dns %>.com
+  system_domain_organization: system_domain
+  app_domains:
+    - <%= dns %>
+
+  networks:
+    apps: default
+    management: default
+
+  nats:
+    address: 0.core.default.<%= name %>.microbosh
+    port: 4222
+    user: nats
+    password: <%= common_password %>
+    authorization_timeout: 5
+
+  router:
+    port: 8081
+    status:
+      port: 8080
+      user: gorouter
+      password: <%= common_password %>
+
+  dea: &dea
+    max_memory: 4096
+    memory_mb: 4084
+    memory_overcommit_factor: 4
+    disk_mb: 4096
+    disk_overcommit_factor: 4
+
+  dea_next: *dea
+
+  syslog_aggregator:
+    address: 0.syslog-aggregator.default.<%= name %>.microbosh
+    port: 54321
+
+  nfs_server:
+    address: 0.data.default.<%= name %>.microbosh
+    #network: "*.<%= name %>.microbosh"
+    #idmapd_domain: <%= dns %>
+
+  debian_nfs_server:
+    no_root_squash: true
+
+  databases: &databases
+    db_scheme: postgres
+    address: 0.data.default.<%= name %>.microbosh
+    port: 5524
+    roles:
+      - tag: admin
+        name: ccadmin
+        password: <%= common_password %>
+      - tag: admin
+        name: uaaadmin
+        password: <%= common_password %>
+    databases:
+      - tag: cc
+        name: ccdb
+        citext: true
+      - tag: uaa
+        name: uaadb
+        citext: true
+
+  ccdb: &ccdb
+    db_scheme: postgres
+    address: 0.data.default.<%= name %>.microbosh
+    port: 5524
+    roles:
+      - tag: admin
+        name: ccadmin
+        password: <%= common_password %>
+    databases:
+      - tag: cc
+        name: ccdb
+        citext: true
+
+  ccdb_ng: *ccdb
+
+  uaadb: 
+    db_scheme: postgresql
+    address: 0.data.default.<%= name %>.microbosh
+    port: 5524
+    roles:
+      - tag: admin
+        name: uaaadmin
+        password: <%= common_password %>
+    databases:
+      - tag: uaa
+        name: uaadb
+        citext: true
+
+  cc_api_version: v2
+
+  cc: &cc
+    logging_level: debug
+    external_host: ccng
+    srv_api_uri: <%= protocol %>://api.<%= dns %>
+    cc_partition: default
+    db_encryption_key: <%= common_password %>
+    bootstrap_admin_email: admin@<%= dns %>
+    bulk_api_password: <%= common_password %>
+    uaa_resource_id: cloud_controller
+    staging_upload_user: uploaduser
+    staging_upload_password: <%= common_password %>
+    resource_pool:
+      resource_directory_key: cc-resources
+      # Local provider when using NFS
+      fog_connection:
+        provider: Local
+        local_root: /var/vcap/shared
+    packages:
+      app_package_directory_key: cc-packages
+    droplets:
+      droplet_directory_key: cc-droplets
+    default_quota_definition: runaway
+
+  ccng: *cc
+
+  login:
+    enabled: false
+
+  uaa:
+    url: <%= protocol %>://uaa.<%= dns %>
+    spring_profiles: postgresql
+    no_ssl: <%= no_ssl %>
+    catalina_opts: -Xmx768m -XX:MaxPermSize=256m
+    resource_id: account_manager
+    jwt:
+      signing_key: |
+        -----BEGIN RSA PRIVATE KEY-----
+        MIICXAIBAAKBgQDHFr+KICms+tuT1OXJwhCUmR2dKVy7psa8xzElSyzqx7oJyfJ1
+        JZyOzToj9T5SfTIq396agbHJWVfYphNahvZ/7uMXqHxf+ZH9BL1gk9Y6kCnbM5R6
+        0gfwjyW1/dQPjOzn9N394zd2FJoFHwdq9Qs0wBugspULZVNRxq7veq/fzwIDAQAB
+        AoGBAJ8dRTQFhIllbHx4GLbpTQsWXJ6w4hZvskJKCLM/o8R4n+0W45pQ1xEiYKdA
+        Z/DRcnjltylRImBD8XuLL8iYOQSZXNMb1h3g5/UGbUXLmCgQLOUUlnYt34QOQm+0
+        KvUqfMSFBbKMsYBAoQmNdTHBaz3dZa8ON9hh/f5TT8u0OWNRAkEA5opzsIXv+52J
+        duc1VGyX3SwlxiE2dStW8wZqGiuLH142n6MKnkLU4ctNLiclw6BZePXFZYIK+AkE
+        xQ+k16je5QJBAN0TIKMPWIbbHVr5rkdUqOyezlFFWYOwnMmw/BKa1d3zp54VP/P8
+        +5aQ2d4sMoKEOfdWH7UqMe3FszfYFvSu5KMCQFMYeFaaEEP7Jn8rGzfQ5HQd44ek
+        lQJqmq6CE2BXbY/i34FuvPcKU70HEEygY6Y9d8J3o6zQ0K9SYNu+pcXt4lkCQA3h
+        jJQQe5uEGJTExqed7jllQ0khFJzLMx0K6tj0NeeIzAaGCQz13oo2sCdeGRHO4aDh
+        HH6Qlq/6UOV5wP8+GAcCQFgRCcB+hrje8hfEEefHcFpyKH+5g1Eu1k0mLrxK2zd+
+        4SlotYRHgPCEubokb2S1zfZDWIXW3HmggnGgM949TlY=
+        -----END RSA PRIVATE KEY-----
+      verification_key: |
+        -----BEGIN PUBLIC KEY-----
+        MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDHFr+KICms+tuT1OXJwhCUmR2d
+        KVy7psa8xzElSyzqx7oJyfJ1JZyOzToj9T5SfTIq396agbHJWVfYphNahvZ/7uMX
+        qHxf+ZH9BL1gk9Y6kCnbM5R60gfwjyW1/dQPjOzn9N394zd2FJoFHwdq9Qs0wBug
+        spULZVNRxq7veq/fzwIDAQAB
+        -----END PUBLIC KEY-----
+    cc:
+      client_secret: <%= common_password %>
+    admin:
+      client_secret: <%= common_password %>
+    batch:
+      username: batchuser
+      password: <%= common_password %>
+    client:
+      autoapprove:
+        - cf
+    clients:
+      cf:
+        override: true
+        authorized-grant-types: password,implicit,refresh_token
+        authorities: uaa.none
+        scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write
+        access-token-validity: 7200
+        refresh-token-validity: 1209600
+    scim:
+      users:
+      - admin|<%= common_password %>|scim.write,scim.read,openid,cloud_controller.admin
+      - services|<%= common_password %>|scim.write,scim.read,openid,cloud_controller.admin

--- a/templates/v136/aws/medium/spec
+++ b/templates/v136/aws/medium/spec
@@ -1,0 +1,6 @@
+---
+resources:
+- small
+- medium
+- large
+- xlarge

--- a/templates/v136/aws/small/README.md
+++ b/templates/v136/aws/small/README.md
@@ -1,0 +1,5 @@
+# Small deployment of Cloud Foundry on AWS
+
+The plan for a small deployment is to colocate everything on a single VM; and allow for scaling in one direction - more/bigger DEAs.
+
+This cannot currently be implemented until a final release of [cf-release](https://github.com/cloudfoundry/cf-release) is published that includes `properties` in each job's `spec` file.

--- a/templates/v136/aws/spec
+++ b/templates/v136/aws/spec
@@ -1,0 +1,6 @@
+---
+deployment_sizes:
+- medium
+- large
+
+default_deployment_size: medium

--- a/templates/v136/openstack/large/deployment_file.yml.erb
+++ b/templates/v136/openstack/large/deployment_file.yml.erb
@@ -1,0 +1,372 @@
+---
+<%-
+# Example source deployment file that can be used:
+# ---
+# name: NAME
+# director_uuid: 4ae3a0f0-70a5-4c0d-95f2-7fafaefe8b9e
+# releases:
+#  - name: cf-release
+#    version: 132
+# networks: {}
+# properties:
+#   cf:
+#     dns: mycloud.com
+#     ip_addresses: ['1.2.3.4']
+#     deployment_size: medium
+#     security_group: cf
+#     persistent_disk: 4096
+#
+# Then target that deployment file:
+#
+#     $ bosh deployment path/to/file/above
+#
+# Then apply this template:
+#
+#     $ bosh diff deployment_file.yml.erb
+#
+name            = find("name")
+dns             = find("properties.cf.dns")
+ip_addresses    = find("properties.cf.ip_addresses")
+security_group  = find("properties.cf.security_group")
+deployment_size = find("properties.cf.deployment_size")
+persistent_disk = find("properties.cf.persistent_disk")
+common_password = find("properties.cf.common_password")
+no_ssl          = true
+protocol        = no_ssl ? "http" : "https"
+-%>
+name: <%= name %>
+director_uuid: <%= find("director_uuid") %>
+
+releases:
+ - name: cf-release
+   version: 136
+
+networks:
+- name: floating
+  type: vip
+  cloud_properties: {}
+- name: default
+  type: dynamic
+  cloud_properties:
+    security_groups:
+    - <%= security_group %>
+
+compilation:
+  workers: 6
+  network: default
+  reuse_compilation_vms: true
+  cloud_properties:
+    instance_type: m1.medium
+
+update:
+  canaries: 1
+  canary_watch_time: 30000-600000
+  update_watch_time: 30000-600000
+  max_in_flight: 4
+  max_errors: 1
+
+resource_pools:
+  - name: small
+    network: default
+    size: 8
+    stemcell:
+      name: bosh-stemcell
+      version: latest
+    cloud_properties:
+      instance_type: m1.small
+
+  - name: large
+    network: default
+    size: 1
+    stemcell:
+      name: bosh-stemcell
+      version: latest
+    cloud_properties:
+      instance_type: m1.large
+
+jobs:
+  - name: syslog_aggregator
+    release: cf-release
+    template: 
+      - syslog_aggregator
+    instances: 1
+    resource_pool: small
+    persistent_disk: 65536
+    networks:
+      - name: default
+        default: [dns, gateway]
+      
+  - name: postgres
+    release: cf-release
+    template: 
+      - postgres
+    instances: 1
+    resource_pool: small
+    persistent_disk: 65536
+    networks:
+      - name: default
+        default: [dns, gateway]
+    properties:
+      db: databases
+
+  - name: nfs_server
+    release: cf-release
+    template:
+      - debian_nfs_server
+    instances: 1
+    resource_pool: small
+    persistent_disk: 65536
+    networks:
+      - name: default
+        default: [dns, gateway]            
+
+  - name: nats
+    release: cf-release
+    template: 
+      - nats
+    instances: 1
+    resource_pool: small
+    networks:
+      - name: default
+        default: [dns, gateway]            
+            
+  - name: uaa
+    release: cf-release
+    template: 
+      - uaa
+    instances: 1
+    resource_pool: small
+    networks:
+      - name: default
+        default: [dns, gateway]           
+
+  - name: cloud_controller
+    release: cf-release
+    template: 
+      - cloud_controller_ng
+    instances: 1
+    resource_pool: small
+    networks:
+      - name: default
+        default: [dns, gateway]
+    properties:
+      ccdb: ccdb
+
+  - name: router
+    release: cf-release
+    template: 
+      - gorouter
+    instances: 1
+    resource_pool: small
+    networks:
+      - name: default
+        default: [dns, gateway]
+      - name: floating
+        static_ips:
+        <%- ip_addresses.each do |ip| -%>
+        - <%= ip %>
+        <%- end -%>
+
+  - name: health_manager
+    release: cf-release
+    template: 
+      - health_manager_next
+    instances: 1
+    resource_pool: small
+    networks:
+      - name: default
+        default: [dns, gateway]
+       
+  - name: dea
+    release: cf-release
+    template: dea_next
+    instances: 1
+    resource_pool: large
+    networks:
+      - name: default
+        default: [dns, gateway]            
+
+properties:
+  cf:
+    name: <%= name %>
+    dns: <%= dns %>
+    ip_addresses: <%= ip_addresses.inspect %>
+    deployment_size: <%= deployment_size %>
+    security_group: <%= security_group %>
+    persistent_disk: <%= persistent_disk %>
+    common_password: <%= common_password %>
+
+  domain: <%= dns %>
+  system_domain: <%= dns %>
+  system_domain_organization: <%= dns %>
+  app_domains:
+    - <%= dns %>
+
+  networks:
+    apps: default
+    management: default
+
+  nats:
+    address: 0.nats.default.<%= name %>.microbosh
+    port: 4222
+    user: nats
+    password: <%= common_password %>
+    authorization_timeout: 5
+
+  router:
+    port: 8081
+    status:
+      port: 8080
+      user: gorouter
+      password: <%= common_password %>
+
+  dea: &dea
+    max_memory: 4096
+    memory_mb: 4096
+    memory_overcommit_factor: 4
+    disk_mb: 16384
+    disk_overcommit_factor: 4
+
+  dea_next: *dea
+
+  syslog_aggregator:
+    address: 0.syslog-aggregator.default.<%= name %>.microbosh
+    port: 54321
+
+  nfs_server:
+    address: 0.nfs-server.default.<%= name %>.microbosh
+    network: "*.<%= name %>.microbosh"
+    idmapd_domain: <%= dns %>
+
+  debian_nfs_server:
+    no_root_squash: true
+
+  databases: &databases
+    db_scheme: postgres
+    address: 0.postgres.default.<%= name %>.microbosh
+    port: 5524
+    roles:
+      - tag: admin
+        name: ccadmin
+        password: <%= common_password %>
+      - tag: admin
+        name: uaaadmin
+        password: <%= common_password %>
+    databases:
+      - tag: cc
+        name: ccdb
+        citext: true
+      - tag: uaa
+        name: uaadb
+        citext: true
+
+  ccdb: &ccdb
+    db_scheme: postgres
+    address: 0.postgres.default.<%= name %>.microbosh
+    port: 5524
+    roles:
+      - tag: admin
+        name: ccadmin
+        password: <%= common_password %>
+    databases:
+      - tag: cc
+        name: ccdb
+        citext: true
+
+  ccdb_ng: *ccdb
+
+  uaadb: 
+    db_scheme: postgresql
+    address: 0.postgres.default.<%= name %>.microbosh
+    port: 5524
+    roles:
+      - tag: admin
+        name: uaaadmin
+        password: <%= common_password %>
+    databases:
+      - tag: uaa
+        name: uaadb
+        citext: true
+
+  cc_api_version: v2
+
+  cc: &cc
+    logging_level: debug
+    external_host: ccng
+    srv_api_uri: <%= protocol %>://api.<%= dns %>
+    cc_partition: default
+    db_encryption_key: <%= common_password %>
+    bootstrap_admin_email: admin@<%= dns %>
+    bulk_api_password: <%= common_password %>
+    uaa_resource_id: cloud_controller
+    staging_upload_user: uploaduser
+    staging_upload_password: <%= common_password %>
+    resource_pool:
+      resource_directory_key: cc-resources
+      # Local provider when using NFS
+      fog_connection:
+        provider: Local
+        local_root: /var/vcap/shared
+    packages:
+      app_package_directory_key: cc-packages
+    droplets:
+      droplet_directory_key: cc-droplets
+    default_quota_definition: runaway
+
+  ccng: *cc
+
+  login:
+    enabled: false
+
+  uaa:
+    url: <%= protocol %>://uaa.<%= dns %>
+    spring_profiles: postgresql
+    no_ssl: <%= no_ssl %>
+    catalina_opts: -Xmx768m -XX:MaxPermSize=256m
+    resource_id: account_manager
+    jwt:
+      signing_key: |
+        -----BEGIN RSA PRIVATE KEY-----
+        MIICXAIBAAKBgQDHFr+KICms+tuT1OXJwhCUmR2dKVy7psa8xzElSyzqx7oJyfJ1
+        JZyOzToj9T5SfTIq396agbHJWVfYphNahvZ/7uMXqHxf+ZH9BL1gk9Y6kCnbM5R6
+        0gfwjyW1/dQPjOzn9N394zd2FJoFHwdq9Qs0wBugspULZVNRxq7veq/fzwIDAQAB
+        AoGBAJ8dRTQFhIllbHx4GLbpTQsWXJ6w4hZvskJKCLM/o8R4n+0W45pQ1xEiYKdA
+        Z/DRcnjltylRImBD8XuLL8iYOQSZXNMb1h3g5/UGbUXLmCgQLOUUlnYt34QOQm+0
+        KvUqfMSFBbKMsYBAoQmNdTHBaz3dZa8ON9hh/f5TT8u0OWNRAkEA5opzsIXv+52J
+        duc1VGyX3SwlxiE2dStW8wZqGiuLH142n6MKnkLU4ctNLiclw6BZePXFZYIK+AkE
+        xQ+k16je5QJBAN0TIKMPWIbbHVr5rkdUqOyezlFFWYOwnMmw/BKa1d3zp54VP/P8
+        +5aQ2d4sMoKEOfdWH7UqMe3FszfYFvSu5KMCQFMYeFaaEEP7Jn8rGzfQ5HQd44ek
+        lQJqmq6CE2BXbY/i34FuvPcKU70HEEygY6Y9d8J3o6zQ0K9SYNu+pcXt4lkCQA3h
+        jJQQe5uEGJTExqed7jllQ0khFJzLMx0K6tj0NeeIzAaGCQz13oo2sCdeGRHO4aDh
+        HH6Qlq/6UOV5wP8+GAcCQFgRCcB+hrje8hfEEefHcFpyKH+5g1Eu1k0mLrxK2zd+
+        4SlotYRHgPCEubokb2S1zfZDWIXW3HmggnGgM949TlY=
+        -----END RSA PRIVATE KEY-----
+      verification_key: |
+        -----BEGIN PUBLIC KEY-----
+        MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDHFr+KICms+tuT1OXJwhCUmR2d
+        KVy7psa8xzElSyzqx7oJyfJ1JZyOzToj9T5SfTIq396agbHJWVfYphNahvZ/7uMX
+        qHxf+ZH9BL1gk9Y6kCnbM5R60gfwjyW1/dQPjOzn9N394zd2FJoFHwdq9Qs0wBug
+        spULZVNRxq7veq/fzwIDAQAB
+        -----END PUBLIC KEY-----
+    cc:
+      client_secret: <%= common_password %>
+    admin:
+      client_secret: <%= common_password %>
+    batch:
+      username: batchuser
+      password: <%= common_password %>
+    client:
+      autoapprove:
+        - cf
+    clients:
+      cf:
+        override: true
+        authorized-grant-types: password,implicit,refresh_token
+        authorities: uaa.none
+        scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write
+        access-token-validity: 7200
+        refresh-token-validity: 1209600
+    scim:
+      users:
+      - admin|<%= common_password %>|scim.write,scim.read,openid,cloud_controller.admin
+      - services|<%= common_password %>|scim.write,scim.read,openid,cloud_controller.admin

--- a/templates/v136/openstack/large/spec
+++ b/templates/v136/openstack/large/spec
@@ -1,0 +1,6 @@
+---
+resources:
+- small
+- medium
+- large
+- xlarge

--- a/templates/v136/openstack/medium/deployment_file.yml.erb
+++ b/templates/v136/openstack/medium/deployment_file.yml.erb
@@ -1,0 +1,331 @@
+---
+<%-
+# Example source deployment file that can be used:
+# ---
+# name: NAME
+# director_uuid: 4ae3a0f0-70a5-4c0d-95f2-7fafaefe8b9e
+# releases:
+#  - name: cf-release
+#    version: 132
+# networks: {}
+# properties:
+#   cf:
+#     dns: mycloud.com
+#     ip_addresses: ['1.2.3.4']
+#     deployment_size: medium
+#     security_group: cf
+#     persistent_disk: 4096
+#
+# Then target that deployment file:
+#
+#     $ bosh deployment path/to/file/above
+#
+# Then apply this template:
+#
+#     $ bosh diff deployment_file.yml.erb
+#
+no_ssl          = true
+protocol        = no_ssl ? "http" : "https"
+name            = find("name")
+dns             = find("properties.cf.dns")
+ip_addresses    = find("properties.cf.ip_addresses")
+security_group  = find("properties.cf.security_group")
+deployment_size = find("properties.cf.deployment_size")
+persistent_disk = find("properties.cf.persistent_disk")
+common_password = find("properties.cf.common_password")
+-%>
+name: <%= name %>
+director_uuid: <%= find("director_uuid") %>
+
+releases:
+ - name: cf-release
+   version: 136
+
+networks:
+- name: floating
+  type: vip
+  cloud_properties: {}
+- name: default
+  type: dynamic
+  cloud_properties:
+    security_groups:
+    - <%= security_group %>
+
+update:
+  canaries: 1
+  canary_watch_time: 30000-600000
+  update_watch_time: 30000-600000
+  max_in_flight: 4
+  max_errors: 1
+
+compilation:
+  workers: 6
+  network: default
+  reuse_compilation_vms: true
+  cloud_properties:
+    instance_type: m1.medium
+
+resource_pools:
+  - name: small
+    network: default
+    size: 4
+    stemcell:
+      name: bosh-stemcell
+      version: latest
+    cloud_properties:
+      instance_type: m1.small
+
+  - name: medium
+    network: default
+    size: 0
+    stemcell:
+      name: bosh-stemcell
+      version: latest
+    cloud_properties:
+      instance_type: m1.medium
+
+jobs:
+  - name: data
+    release: cf-release
+    template:
+      - postgres
+      - debian_nfs_server
+    instances: 1
+    resource_pool: small
+    persistent_disk: <%= persistent_disk %>
+    networks:
+    - name: default
+      default:
+      - dns
+      - gateway
+    properties:
+      db: databases
+
+  - name: core
+    release: cf-release
+    template:
+      - nats
+      - health_manager_next
+      - uaa
+    instances: 1
+    resource_pool: small
+    networks:
+    - name: default
+      default:
+      - dns
+      - gateway
+
+  - name: api
+    release: cf-release
+    template:
+      - cloud_controller_ng
+      - gorouter
+    instances: 1
+    resource_pool: small
+    networks:
+    - name: default
+      default:
+      - dns
+      - gateway
+    - name: floating
+      static_ips:
+      <%- ip_addresses.each do |ip| -%>
+      - <%= ip %>
+      <%- end -%>
+    properties:
+      db: databases
+
+  - name: dea
+    release: cf-release
+    template:
+      - dea_next
+    instances: 1
+    resource_pool: small
+    networks:
+      - name: default
+        default: [dns, gateway]
+
+properties:
+  cf:
+    name: <%= name %>
+    dns: <%= dns %>
+    ip_addresses: <%= ip_addresses.inspect %>
+    deployment_size: <%= deployment_size %>
+    security_group: <%= security_group %>
+    persistent_disk: <%= persistent_disk %>
+    common_password: <%= common_password %>
+
+  domain: <%= dns %>
+  system_domain: <%= dns %>.com
+  system_domain_organization: system_domain
+  app_domains:
+    - <%= dns %>
+
+  networks:
+    apps: default
+    management: default
+
+  nats:
+    address: 0.core.default.<%= name %>.microbosh
+    port: 4222
+    user: nats
+    password: <%= common_password %>
+    authorization_timeout: 5
+
+  router:
+    port: 8081
+    status:
+      port: 8080
+      user: gorouter
+      password: <%= common_password %>
+
+  dea: &dea
+    max_memory: 4096
+    memory_mb: 4084
+    memory_overcommit_factor: 4
+    disk_mb: 4096
+    disk_overcommit_factor: 4
+
+  dea_next: *dea
+
+  syslog_aggregator:
+    address: 0.syslog-aggregator.default.<%= name %>.microbosh
+    port: 54321
+
+  nfs_server:
+    address: 0.data.default.<%= name %>.microbosh
+    #network: "*.<%= name %>.microbosh"
+    #idmapd_domain: <%= dns %>
+
+  debian_nfs_server:
+    no_root_squash: true
+
+  databases: &databases
+    db_scheme: postgres
+    address: 0.data.default.<%= name %>.microbosh
+    port: 5524
+    roles:
+      - tag: admin
+        name: ccadmin
+        password: <%= common_password %>
+      - tag: admin
+        name: uaaadmin
+        password: <%= common_password %>
+    databases:
+      - tag: cc
+        name: ccdb
+        citext: true
+      - tag: uaa
+        name: uaadb
+        citext: true
+
+  ccdb: &ccdb
+    db_scheme: postgres
+    address: 0.data.default.<%= name %>.microbosh
+    port: 5524
+    roles:
+      - tag: admin
+        name: ccadmin
+        password: <%= common_password %>
+    databases:
+      - tag: cc
+        name: ccdb
+        citext: true
+
+  ccdb_ng: *ccdb
+
+  uaadb: 
+    db_scheme: postgresql
+    address: 0.data.default.<%= name %>.microbosh
+    port: 5524
+    roles:
+      - tag: admin
+        name: uaaadmin
+        password: <%= common_password %>
+    databases:
+      - tag: uaa
+        name: uaadb
+        citext: true
+
+  cc_api_version: v2
+
+  cc: &cc
+    logging_level: debug
+    external_host: ccng
+    srv_api_uri: <%= protocol %>://api.<%= dns %>
+    cc_partition: default
+    db_encryption_key: <%= common_password %>
+    bootstrap_admin_email: admin@<%= dns %>
+    bulk_api_password: <%= common_password %>
+    uaa_resource_id: cloud_controller
+    staging_upload_user: uploaduser
+    staging_upload_password: <%= common_password %>
+    resource_pool:
+      resource_directory_key: cc-resources
+      # Local provider when using NFS
+      fog_connection:
+        provider: Local
+        local_root: /var/vcap/shared
+    packages:
+      app_package_directory_key: cc-packages
+    droplets:
+      droplet_directory_key: cc-droplets
+    default_quota_definition: runaway
+
+  ccng: *cc
+
+  login:
+    enabled: false
+
+  uaa:
+    url: <%= protocol %>://uaa.<%= dns %>
+    spring_profiles: postgresql
+    no_ssl: <%= no_ssl %>
+    catalina_opts: -Xmx768m -XX:MaxPermSize=256m
+    resource_id: account_manager
+    jwt:
+      signing_key: |
+        -----BEGIN RSA PRIVATE KEY-----
+        MIICXAIBAAKBgQDHFr+KICms+tuT1OXJwhCUmR2dKVy7psa8xzElSyzqx7oJyfJ1
+        JZyOzToj9T5SfTIq396agbHJWVfYphNahvZ/7uMXqHxf+ZH9BL1gk9Y6kCnbM5R6
+        0gfwjyW1/dQPjOzn9N394zd2FJoFHwdq9Qs0wBugspULZVNRxq7veq/fzwIDAQAB
+        AoGBAJ8dRTQFhIllbHx4GLbpTQsWXJ6w4hZvskJKCLM/o8R4n+0W45pQ1xEiYKdA
+        Z/DRcnjltylRImBD8XuLL8iYOQSZXNMb1h3g5/UGbUXLmCgQLOUUlnYt34QOQm+0
+        KvUqfMSFBbKMsYBAoQmNdTHBaz3dZa8ON9hh/f5TT8u0OWNRAkEA5opzsIXv+52J
+        duc1VGyX3SwlxiE2dStW8wZqGiuLH142n6MKnkLU4ctNLiclw6BZePXFZYIK+AkE
+        xQ+k16je5QJBAN0TIKMPWIbbHVr5rkdUqOyezlFFWYOwnMmw/BKa1d3zp54VP/P8
+        +5aQ2d4sMoKEOfdWH7UqMe3FszfYFvSu5KMCQFMYeFaaEEP7Jn8rGzfQ5HQd44ek
+        lQJqmq6CE2BXbY/i34FuvPcKU70HEEygY6Y9d8J3o6zQ0K9SYNu+pcXt4lkCQA3h
+        jJQQe5uEGJTExqed7jllQ0khFJzLMx0K6tj0NeeIzAaGCQz13oo2sCdeGRHO4aDh
+        HH6Qlq/6UOV5wP8+GAcCQFgRCcB+hrje8hfEEefHcFpyKH+5g1Eu1k0mLrxK2zd+
+        4SlotYRHgPCEubokb2S1zfZDWIXW3HmggnGgM949TlY=
+        -----END RSA PRIVATE KEY-----
+      verification_key: |
+        -----BEGIN PUBLIC KEY-----
+        MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDHFr+KICms+tuT1OXJwhCUmR2d
+        KVy7psa8xzElSyzqx7oJyfJ1JZyOzToj9T5SfTIq396agbHJWVfYphNahvZ/7uMX
+        qHxf+ZH9BL1gk9Y6kCnbM5R60gfwjyW1/dQPjOzn9N394zd2FJoFHwdq9Qs0wBug
+        spULZVNRxq7veq/fzwIDAQAB
+        -----END PUBLIC KEY-----
+    cc:
+      client_secret: <%= common_password %>
+    admin:
+      client_secret: <%= common_password %>
+    batch:
+      username: batchuser
+      password: <%= common_password %>
+    client:
+      autoapprove:
+        - cf
+    clients:
+      cf:
+        override: true
+        authorized-grant-types: password,implicit,refresh_token
+        authorities: uaa.none
+        scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write
+        access-token-validity: 7200
+        refresh-token-validity: 1209600
+    scim:
+      users:
+      - admin|<%= common_password %>|scim.write,scim.read,openid,cloud_controller.admin
+      - services|<%= common_password %>|scim.write,scim.read,openid,cloud_controller.admin

--- a/templates/v136/openstack/medium/spec
+++ b/templates/v136/openstack/medium/spec
@@ -1,0 +1,6 @@
+---
+resources:
+- small
+- medium
+- large
+- xlarge

--- a/templates/v136/openstack/spec
+++ b/templates/v136/openstack/spec
@@ -1,0 +1,6 @@
+---
+deployment_sizes:
+- medium
+- large
+
+default_deployment_size: medium

--- a/templates/v136/spec
+++ b/templates/v136/spec
@@ -1,0 +1,14 @@
+---
+available_cpi:
+- aws
+- openstack
+
+mutable_attributes:
+- ip_addresses
+- persistent_disk
+- security_group
+- dns
+immutable_attributes:
+- common_password
+- deployment_size
+- name


### PR DESCRIPTION
Skipping v135 as the tool doesn't yet support upgrades (must do it manually) so its only necessary to implement templates for new users at the moment.
