### PR TITLE
Add option --base-stemcell-url to 'prepare cf' command.

### DIFF
--- a/lib/bosh/cli/commands/01_prepare_bosh_for_cf.rb
+++ b/lib/bosh/cli/commands/01_prepare_bosh_for_cf.rb
@@ -8,11 +8,14 @@ module Bosh::Cli::Command
     usage "prepare cf"
     desc "upload latest Cloud Foundry release to bosh"
     option "--release-version version", "Upload a specific older version"
+    option "--base-stemcell-url http://example.com/stemcell.tgz", "Specify an alternate stemcell"
     def prepare_cf
       auth_required
       bosh_status
 
       release_version = options[:release_version] || latest_release_version
+      stemcell_url = options[:base_stemcell_url] ||
+          "http://bosh-jenkins-artifacts.s3.amazonaws.com/bosh-stemcell/#{bosh_cpi}/latest-bosh-stemcell-#{bosh_cpi}.tgz"
 
       # Support:
       # * --release-version v132
@@ -49,7 +52,6 @@ module Bosh::Cli::Command
       end
       unless errors.empty?
         say errors.shift.make_yellow
-        stemcell_url = "http://bosh-jenkins-artifacts.s3.amazonaws.com/bosh-stemcell/#{bosh_cpi}/latest-bosh-stemcell-#{bosh_cpi}.tgz"
         stemcell_cmd(non_interactive: true).upload(stemcell_url)
       end
     end


### PR DESCRIPTION
This allows to specify an alternate stemcell in case you need to tweak some parameters of the publicly available Bosh stemcell.

I needed it because my images need to know about my HTTP proxy settings. I'll let you decide if it's useful for others.
