### PR TITLE
Add an option to skip DNS mapping validation

### DIFF
--- a/lib/bosh/cli/commands/02_create_cf.rb
+++ b/lib/bosh/cli/commands/02_create_cf.rb
@@ -15,6 +15,7 @@ module Bosh::Cli::Command
     option "--disk 4096", Integer, "Size of persistent disk (Mb)"
     option "--security-group default", String, "Security group to assign to provisioned VMs"
     option "--deployment-size medium", String, "Size of deployment - medium or large"
+    option "--skip-dns-validation", "Skip DNS validation"
     def create_cf
       auth_required
       bosh_status # preload
@@ -32,6 +33,7 @@ module Bosh::Cli::Command
       attrs.set_unless_nil(:security_group, options[:security_group])
       attrs.set_unless_nil(:common_password, options[:common_password])
       attrs.set_unless_nil(:deployment_size, options[:deployment_size])
+      attrs.set_unless_nil(:skip_dns_validation, options[:skip_dns_validation])
 
       release_version = ReleaseVersion.latest_version_number
       @release_version_cpi_size = 

--- a/lib/bosh/cloudfoundry/deployment_attributes.rb
+++ b/lib/bosh/cloudfoundry/deployment_attributes.rb
@@ -18,6 +18,7 @@ module Bosh::Cloudfoundry
       @attributes[:persistent_disk] ||= default_persistent_disk
       @attributes[:security_group] ||= default_security_group
       @attributes[:common_password] ||= random_string(12, :common)
+      @attributes[:skip_dns_validation] ||= default_skip_dns_validation
     end
 
     def name
@@ -106,8 +107,10 @@ module Bosh::Cloudfoundry
 
     # FIXME only supports a single ip_address
     def validate_dns_mapping
-      validate_dns_a_record("api.#{dns}", ip_addresses.first)
-      validate_dns_a_record("demoapp.#{dns}", ip_addresses.first)
+      unless @attributes[:skip_dns_validation]
+        validate_dns_a_record("api.#{dns}", ip_addresses.first)
+        validate_dns_a_record("demoapp.#{dns}", ip_addresses.first)
+      end
     end
 
     def validate_dns_a_record(domain, expected_ip_address)
@@ -189,6 +192,10 @@ module Bosh::Cloudfoundry
 
     def default_security_group
       "default"
+    end
+
+    def default_skip_dns_validation
+      false
     end
 
     def set_default_dns

--- a/spec/deployment_attributes_spec.rb
+++ b/spec/deployment_attributes_spec.rb
@@ -35,7 +35,7 @@ describe Bosh::Cloudfoundry::DeploymentAttributes do
     it "returns default attributes" do
       subject = Bosh::Cloudfoundry::DeploymentAttributes.new(director, bosh_status, release_version_cpi)
       subject.available_attributes.sort.should ==
-        %w[common_password deployment_size name persistent_disk security_group].map(&:to_sym)
+        %w[common_password deployment_size name persistent_disk security_group skip_dns_validation].map(&:to_sym)
     end
 
     it "returns additional attributes" do
@@ -43,7 +43,7 @@ describe Bosh::Cloudfoundry::DeploymentAttributes do
         dns: "mycloud.com", ip_addresses: ["1.2.3.4"]
       })
       subject.available_attributes.sort.should ==
-        %w[common_password deployment_size dns ip_addresses name persistent_disk security_group].map(&:to_sym)
+        %w[common_password deployment_size dns ip_addresses name persistent_disk security_group skip_dns_validation].map(&:to_sym)
     end
 
     # immutable_attributes ultimately determined by ReleaseVersion (from templates/vXYZ/spec)


### PR DESCRIPTION
When we deploy a CF instance behind load balancers or reverse proxies, the DNS name specified with the `--dns` option is not directly mapped to  the IP addresses for the instance. I added a new option to skip DNS mapping validation for such deployments.
