### PR TITLE
Update build-your-own-heroku-with-cloudfoundry.md

### DIFF
--- a/tutorials/build-your-own-heroku-with-cloudfoundry.md
+++ b/tutorials/build-your-own-heroku-with-cloudfoundry.md
@@ -190,7 +190,7 @@ $ git clone https://github.com/cloudfoundry-community/cf-env.git
 $ cd cf-env
 $ bundle
 
-$ cf push env
+$ cf push
 Instances> 1
 
 1: 128M


### PR DESCRIPTION
The "env" is not needed and causes an error
