### PR TITLE
remove nfs mount locations, use default instead

### DIFF
--- a/templates/v146/aws/large/deployment_file.yml.erb
+++ b/templates/v146/aws/large/deployment_file.yml.erb
@@ -307,7 +307,6 @@ properties:
       # Local provider when using NFS
       fog_connection:
         provider: Local
-        local_root: /var/vcap/shared
     packages:
       app_package_directory_key: cc-packages
     droplets:

--- a/templates/v146/aws/medium/deployment_file.yml.erb
+++ b/templates/v146/aws/medium/deployment_file.yml.erb
@@ -266,7 +266,6 @@ properties:
       # Local provider when using NFS
       fog_connection:
         provider: Local
-        local_root: /var/vcap/shared
     packages:
       app_package_directory_key: cc-packages
     droplets:

--- a/templates/v146/openstack/large/deployment_file.yml.erb
+++ b/templates/v146/openstack/large/deployment_file.yml.erb
@@ -306,7 +306,6 @@ properties:
       # Local provider when using NFS
       fog_connection:
         provider: Local
-        local_root: /var/vcap/shared
     packages:
       app_package_directory_key: cc-packages
     droplets:

--- a/templates/v146/openstack/medium/deployment_file.yml.erb
+++ b/templates/v146/openstack/medium/deployment_file.yml.erb
@@ -265,7 +265,6 @@ properties:
       # Local provider when using NFS
       fog_connection:
         provider: Local
-        local_root: /var/vcap/shared
     packages:
       app_package_directory_key: cc-packages
     droplets:


### PR DESCRIPTION
Remove NFS mount point locations as they are not required.

There is a post from James Bayer on VCAP-DEV about this here:
https://groups.google.com/a/cloudfoundry.org/d/msg/vcap-dev/IqMCuSzEDFs/hYO11GPWMpYJ

Seems that having the mount points cause more problems than they resolve.
