### PR TITLE
adding explicit http prefix to 'cf target'

### DIFF
--- a/tutorials/build-your-own-heroku-with-cloudfoundry.md
+++ b/tutorials/build-your-own-heroku-with-cloudfoundry.md
@@ -169,7 +169,7 @@ $ bosh deploy
 $ bosh show cf attributes
 
 $ gem install cf
-$ cf target api.1.2.3.4.xip.io
+$ cf target http://api.1.2.3.4.xip.io
 Common password: 6d7fe84f828b
 $ cf login admin
 Password> 6d7fe84f828b


### PR DESCRIPTION
Adding http prefix to 'cf target' command (tutorial wiki). Otherwise CF uses https by default and fails with "connection refused" error
